### PR TITLE
fix: document bun as required runtime

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -8,20 +8,30 @@ AI coding agents load skills into their context window on every session. More sk
 
 **skillkit** answers these questions with usage analytics, conflict detection, cost analysis, and context budget monitoring — all locally on your machine.
 
-## Quick Start
+## Prerequisites
+
+skillkit requires [Bun](https://bun.sh) as its runtime (for native SQLite and fast TypeScript execution).
 
 ```bash
-npx @crafter/skillkit scan
-npx @crafter/skillkit stats
-npx @crafter/skillkit health
+curl -fsSL https://bun.sh/install | bash
+```
+
+## Quick start
+
+```bash
+bunx @crafter/skillkit scan
+bunx @crafter/skillkit stats
+bunx @crafter/skillkit health
 ```
 
 Or install globally:
 
 ```bash
-npm i -g @crafter/skillkit
+bun add -g @crafter/skillkit
 skillkit scan
 ```
+
+> **Note:** `npm i -g` also works if bun is installed, since the bin entry uses bun as its runtime.
 
 ## Commands
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@crafter/skillkit",
-	"version": "0.8.0",
+	"version": "0.8.1",
 	"description": "Local-first analytics for AI agent skills. Track usage, measure context budget, and prune what you don't use.",
 	"type": "module",
 	"bin": {
@@ -44,7 +44,8 @@
 		"url": "https://github.com/crafter-station/skill-kit/issues"
 	},
 	"engines": {
-		"bun": ">=1.0.0"
+		"bun": ">=1.0.0",
+		"node": ">=18.0.0"
 	},
 	"devDependencies": {
 		"@types/bun": "^1.2.14",


### PR DESCRIPTION
Closes #15

- Add Prerequisites section to README with bun install instructions
- Update Quick Start to use `bunx` instead of `npx`
- Add note that `npm i -g` works if bun is installed
- Add `node: >=18.0.0` to engines field
- Bump to 0.8.1