### PR TITLE
fix: infinite recursion in isInternalTool (codex.ts)

### DIFF
--- a/packages/cli/src/scanner/connectors/codex.ts
+++ b/packages/cli/src/scanner/connectors/codex.ts
@@ -14,7 +14,7 @@ const CODEX_INTERNAL_TOOLS = new Set([
 ]);
 
 function isInternalTool(name: string): boolean {
-	return isInternalTool(name) || name.startsWith("mcp__") || name.startsWith("mcp_");
+	return CODEX_INTERNAL_TOOLS.has(name) || name.startsWith("mcp__") || name.startsWith("mcp_");
 }
 
 const SKILL_PATH_RE = /skills\/([^/]+)\/SKILL\.md/;


### PR DESCRIPTION
## Summary

- `isInternalTool` was calling itself recursively instead of checking `CODEX_INTERNAL_TOOLS.has(name)`
- This caused `RangeError: Maximum call stack size exceeded` on every `skillkit stats` run
- One-line fix: `isInternalTool(name)` → `CODEX_INTERNAL_TOOLS.has(name)`

Closes #18

## Test plan

- [ ] Run `skillkit stats` — should complete without stack overflow
- [ ] Verify MCP tools and known internal tools are still correctly filtered

🤖 Generated with [Claude Code](https://claude.com/claude-code)