### PR TITLE
fix(web): align site claims with actual CLI capabilities

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
 		card: "summary_large_image",
 		title: "SkillKit",
 		description:
-			"Local-first analytics for AI agent skills. 15+ agents supported.",
+			"Local-first analytics for AI agent skills. Session tracking for 5 agents, skill discovery across 12.",
 	},
 };
 

--- a/apps/web/src/components/agent-logo-belt.tsx
+++ b/apps/web/src/components/agent-logo-belt.tsx
@@ -36,6 +36,8 @@ const AGENTS: AgentEntry[] = [
 	{ name: "Windsurf", logo: WindsurfLogo, issue: 3 },
 	{ name: "Cline", logo: ClineLogo, issue: 5 },
 	{ name: "Roo Code", logo: RooCodeLogo, issue: 6 },
+	{ name: "Continue", issue: 7 },
+	{ name: "Amp", issue: 10 },
 	{ name: "GitHub Copilot", logo: GithubCopilotLogo, issue: 8 },
 	{ name: "OpenHands", logo: OpenHandsLogo, issue: 9 },
 	{ name: "Goose", logo: GooseLogo, issue: 11 },

--- a/apps/web/src/components/commands-showcase.tsx
+++ b/apps/web/src/components/commands-showcase.tsx
@@ -76,6 +76,47 @@ const COMMANDS: Command[] = [
 		],
 	},
 	{
+		name: "context",
+		cmd: "skillkit context --opus",
+		description: "Context tax: tokens + cost loaded on every API call",
+		lines: [
+			{ text: "  CONTEXT TAX — opus pricing, 40 turns/session", type: "header" },
+			{ text: "", type: "empty" },
+			{ text: "  ALWAYS LOADED (every API call)", type: "header" },
+			{ text: "  CLAUDE.md + refs        12.5K tokens   $0.0188", type: "white" },
+			{ text: "  Skills metadata          2.6K tokens   $0.0039", type: "white" },
+			{ text: "  Memory (MEMORY.md)       3.9K tokens   $0.0058", type: "white" },
+			{ text: "  ────────────────────────────────────────────", type: "dim" },
+			{ text: "  Total                   19.0K tokens   $0.0285/call", type: "accent" },
+			{ text: "", type: "empty" },
+			{ text: "  SESSION ESTIMATE (40 turns)", type: "header" },
+			{ text: "  With prompt caching     $1.29", type: "accent" },
+			{ text: "  Without caching         $10.04", type: "white" },
+			{ text: "  Cache savings           87%", type: "dim" },
+		],
+	},
+	{
+		name: "health",
+		cmd: "skillkit health",
+		description: "Unused skills, context budget, DB health",
+		lines: [
+			{ text: "  SKILLKIT HEALTH REPORT", type: "header" },
+			{ text: "", type: "empty" },
+			{ text: "  ✓ 43 skills installed", type: "accent" },
+			{ text: "  ✓ Analytics DB: 11,848 events tracked", type: "accent" },
+			{ text: "", type: "empty" },
+			{ text: "  ⚠ 6 skills never used in 30d", type: "white" },
+			{ text: "    Run: skillkit prune", type: "dim" },
+			{ text: "", type: "empty" },
+			{ text: "  [███░░░░░░░] 34% metadata budget (5.4K / 16.0K)", type: "white" },
+			{ text: "    name + description of each skill, loaded at startup", type: "dim" },
+			{ text: "  ● Total skill content: 103.8K chars (loaded on-demand)", type: "white" },
+			{ text: "", type: "empty" },
+			{ text: "  ⚠ 1 skill exceeds 500-line recommendation", type: "white" },
+			{ text: "    Split SKILL.md into referenced files", type: "dim" },
+		],
+	},
+	{
 		name: "graph",
 		cmd: "skillkit graph",
 		description: "52-week contribution heatmap",
@@ -141,7 +182,7 @@ export function CommandsShowcase() {
 					className="text-center mb-16"
 				>
 					<h2 className="text-4xl md:text-5xl font-serif italic text-white">
-						Five commands. Full picture.
+						One CLI. Full picture.
 					</h2>
 					<p className="text-[#888] mt-3 text-sm">
 						Everything runs locally. No accounts, no telemetry, no cloud.
@@ -208,7 +249,7 @@ export function CommandsShowcase() {
 						>
 							<span>skillkit v0.10</span>
 							<span>local-first</span>
-							<span>12 agents</span>
+							<span>13 commands</span>
 						</div>
 					</div>
 				</motion.div>

--- a/apps/web/src/components/comparison-table.tsx
+++ b/apps/web/src/components/comparison-table.tsx
@@ -18,7 +18,7 @@ const ROWS: Row[] = [
 	{ feature: "Registry search", skillkit: false, skillssh: true, straude: false, manual: false },
 	{ feature: "Usage analytics + sparklines", skillkit: true, skillssh: false, straude: true, manual: false },
 	{ feature: "Burn rate (40+ models)", skillkit: true, skillssh: false, straude: true, manual: false },
-	{ feature: "Multi-agent (12 agents)", skillkit: true, skillssh: false, straude: false, manual: false },
+	{ feature: "Multi-agent (5 sessions, 12 skill scans)", skillkit: true, skillssh: false, straude: false, manual: false },
 	{ feature: "Streaks & velocity", skillkit: true, skillssh: false, straude: true, manual: false },
 	{ feature: "Contribution heatmap", skillkit: true, skillssh: false, straude: true, manual: false },
 	{ feature: "Context budget tracking", skillkit: true, skillssh: false, straude: false, manual: false },

--- a/apps/web/src/components/faq.tsx
+++ b/apps/web/src/components/faq.tsx
@@ -11,12 +11,12 @@ const ITEMS = [
 	{
 		question: "How is this different from Straude?",
 		answer:
-			"Straude tracks Claude Code usage and uploads it to a cloud leaderboard. SkillKit is local-first (your data never leaves your machine), supports 12 agents instead of just Claude, and focuses on efficiency rather than rewarding spend.",
+			"Straude tracks Claude Code usage and uploads it to a cloud leaderboard. SkillKit is local-first (your data never leaves your machine), tracks sessions from 5 agents instead of just Claude, and focuses on efficiency rather than rewarding spend.",
 	},
 	{
 		question: "Which AI coding agents are supported?",
 		answer:
-			"Claude Code, Cursor, Codex, Gemini CLI, Windsurf, OpenCode, Amp, Continue, Goose, Kiro, Roo Code, and Antigravity. Filter any command with --claude, --cursor, --codex, etc.",
+			"Session analytics (burn, sessions, graph): Claude Code, Cursor, Codex, Gemini CLI, and OpenCode, with filters like --claude, --cursor, --codex. Skill discovery (scan, list, health): those plus Windsurf, Amp, Continue, Goose, Kiro, Roo Code, and Antigravity. More session connectors are tracked as open issues on GitHub.",
 	},
 	{
 		question: "Is SkillKit free?",

--- a/apps/web/src/components/feature-bento.tsx
+++ b/apps/web/src/components/feature-bento.tsx
@@ -9,7 +9,7 @@ const cards = [
 		icon: Flame,
 		title: "Burn Rate Analysis",
 		description:
-			"Track token spend across Claude, Cursor, Codex, and 9 more agents. Daily burn, model breakdown, and plan utilization.",
+			"Track token spend across Claude Code, Cursor, Codex, Gemini CLI, and OpenCode. Daily burn, model breakdown, and plan utilization.",
 	},
 	{
 		id: "sessions",

--- a/apps/web/src/components/hero.tsx
+++ b/apps/web/src/components/hero.tsx
@@ -57,7 +57,8 @@ export function Hero() {
 					className="text-lg text-[#888] max-w-2xl leading-relaxed"
 				>
 					Observability for AI coding agents. Track burn rate, sessions, streaks,
-					and contribution graphs across Claude, Cursor, Codex, and 9 more — all local, all offline.
+					and contribution graphs across Claude Code, Cursor, Codex, Gemini CLI, and
+						OpenCode, plus skill discovery for 12 agents — all local, all offline.
 				</motion.p>
 
 				<motion.div

--- a/apps/web/src/components/terminal-demo.tsx
+++ b/apps/web/src/components/terminal-demo.tsx
@@ -246,7 +246,7 @@ export function TerminalDemo() {
 					style={{ background: "#0e0e0e" }}
 				>
 					<span>-- NORMAL --</span>
-					<span>skillkit v0.9.0</span>
+					<span>skillkit v0.10</span>
 					<span>utf-8</span>
 				</div>
 			</div>


### PR DESCRIPTION
## What

Parity pass between the website and the actual CLI (v0.10.6).

## Fixes

**Inflated agent claims.** The site conflated two different tiers. Reality: session analytics (burn/sessions/graph) supports 5 agents (Claude Code, Cursor, Codex, Gemini CLI, OpenCode via `scanner/connectors/`); skill discovery (scan/list/health) covers 12 agent skill directories. Patched:
- Hero: 'Claude, Cursor, Codex, and 9 more' -> names the 5 session agents + '12 agents' scoped to skill discovery
- Feature bento (burn card): same fix
- FAQ: supported-agents answer now explains both tiers; Straude answer '12 agents' -> '5 agents'
- Comparison table: 'Multi-agent (12 agents)' -> '(5 sessions, 12 skill scans)'
- Layout metadata: '15+ agents supported' (never true) -> accurate description

**Missing commands.** Showcase claimed 'Five commands. Full picture.' while the CLI has 13. Added `context` and `health` tabs (output from real CLI runs), headline no longer hardcodes a count, footer chip '12 agents' -> '13 commands'.

**Agent belt gaps.** Coming-soon belt linked 8 of 10 open connector issues; added Continue (#7) and Amp (#10) with the initials fallback (no logo assets yet).

**Stale version.** Terminal demo footer said v0.9.0; CLI is 0.10.x.

## Verified

- `tsc --noEmit` clean
- Biome: only pre-existing findings (og-image formatting, import order), none in changed lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBRGWen5utt7WBNtBKdMtU