### PR TITLE
fix(scanner): index plugin-bundled skills from installed_plugins.json

### DIFF
--- a/packages/cli/src/commands/list.ts
+++ b/packages/cli/src/commands/list.ts
@@ -1,4 +1,4 @@
-import { scanInstalledSkills } from "../scanner/skills";
+import { detectSkillSource, scanInstalledSkills } from "../scanner/skills";
 import { bold, cyan, dim } from "../tui/colors";
 
 function formatSize(bytes: number): string {
@@ -25,10 +25,11 @@ export function runList(): void {
 	console.log(`\n  ${bold(`INSTALLED SKILLS (${skills.length})`)}\n`);
 
 	const nameWidth = 24;
-	const descWidth = 42;
+	const descWidth = 34;
+	const sourceWidth = 14;
 	const sizeWidth = 10;
 
-	const header = `  ${"NAME".padEnd(nameWidth)}${"DESCRIPTION".padEnd(descWidth)}${"SIZE".padStart(sizeWidth)}`;
+	const header = `  ${"NAME".padEnd(nameWidth)}${"DESCRIPTION".padEnd(descWidth)}${"SOURCE".padEnd(sourceWidth)}${"SIZE".padStart(sizeWidth)}`;
 	console.log(dim(header));
 
 	for (const skill of skills) {
@@ -36,8 +37,16 @@ export function runList(): void {
 		const desc = dim(
 			truncate(skill.description || "", descWidth).padEnd(descWidth),
 		);
+		const rawSource = detectSkillSource(skill);
+		const sourceLabel =
+			rawSource === "manual" || rawSource === "skills.sh"
+				? rawSource
+				: (rawSource.split("@")[0] ?? rawSource);
+		const source = dim(
+			truncate(sourceLabel, sourceWidth - 1).padEnd(sourceWidth),
+		);
 		const size = formatSize(skill.size).padStart(sizeWidth);
-		console.log(`  ${name}${desc}${size}`);
+		console.log(`  ${name}${desc}${source}${size}`);
 	}
 
 	console.log(

--- a/packages/cli/src/commands/prune.ts
+++ b/packages/cli/src/commands/prune.ts
@@ -1,4 +1,12 @@
-import { existsSync, lstatSync, readFileSync, readdirSync, rmSync, unlinkSync, writeFileSync } from "node:fs";
+import {
+	existsSync,
+	lstatSync,
+	readdirSync,
+	readFileSync,
+	rmSync,
+	unlinkSync,
+	writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { getTopSkills } from "../db/queries";
@@ -29,7 +37,9 @@ function removeFromLockFile(skillName: string): void {
 			delete data.skills[skillName];
 			writeFileSync(LOCK_PATH, JSON.stringify(data, null, 2) + "\n", "utf-8");
 		}
-	} catch { /* empty */ }
+	} catch {
+		/* empty */
+	}
 }
 
 function removeSymlinks(skillName: string): number {
@@ -43,7 +53,9 @@ function removeSymlinks(skillName: string): number {
 				unlinkSync(linkPath);
 				cleaned++;
 			}
-		} catch { /* empty */ }
+		} catch {
+			/* empty */
+		}
 	}
 	return cleaned;
 }
@@ -53,7 +65,9 @@ function isRegistrySkill(skillName: string): boolean {
 	try {
 		const data = JSON.parse(readFileSync(LOCK_PATH, "utf-8"));
 		return !!(data.skills && data.skills[skillName]);
-	} catch { /* empty */ }
+	} catch {
+		/* empty */
+	}
 	return false;
 }
 
@@ -72,7 +86,9 @@ function removeSkillClean(name: string, path: string): boolean {
 			}
 		}
 		return true;
-	} catch { /* empty */ }
+	} catch {
+		/* empty */
+	}
 	return false;
 }
 
@@ -94,7 +110,10 @@ export async function runPrune(): Promise<void> {
 
 	const topSkills = getTopSkills(db, 30);
 	const usedNames = new Set(topSkills.map((s) => s.skill_name));
-	const unused = skills.filter((s) => !usedNames.has(s.name));
+	const pluginManaged = skills.filter(
+		(s) => s.source && !usedNames.has(s.name),
+	);
+	const unused = skills.filter((s) => !s.source && !usedNames.has(s.name));
 
 	if (unused.length === 0) {
 		console.log(
@@ -112,7 +131,9 @@ export async function runPrune(): Promise<void> {
 		if (existsSync(skillMdPath)) {
 			try {
 				chars = readFileSync(skillMdPath, "utf-8").length;
-			} catch { /* empty */ }
+			} catch {
+				/* empty */
+			}
 		}
 		totalWaste += chars;
 		candidates.push({ name: skill.name, path: skill.path, chars });
@@ -132,6 +153,12 @@ export async function runPrune(): Promise<void> {
 		`\n  ${bold(String(candidates.length))} skills ${dim("·")} ${bold(`${(totalWaste / 1000).toFixed(1)}K`)} ${dim("context reclaimable")}`,
 	);
 
+	if (pluginManaged.length > 0) {
+		console.log(
+			`  ${dim(`${pluginManaged.length} unused plugin-bundled skills skipped (managed via /plugin, would be restored on update)`)}`,
+		);
+	}
+
 	const args = process.argv.slice(3);
 
 	const skillFlag = args.indexOf("--skill");
@@ -142,7 +169,9 @@ export async function runPrune(): Promise<void> {
 		: candidates;
 
 	if (targetSkill && targets.length === 0) {
-		console.log(`\n  ${dim(`Skill "${targetSkill}" is not in the prune list (either used recently or not installed).`)}\n`);
+		console.log(
+			`\n  ${dim(`Skill "${targetSkill}" is not in the prune list (either used recently or not installed).`)}\n`,
+		);
 		return;
 	}
 
@@ -169,7 +198,13 @@ export async function runPrune(): Promise<void> {
 	}
 
 	if (isJson) {
-		console.log(JSON.stringify({ removed: removedNames, count: removed, reclaimed_chars: totalWaste }));
+		console.log(
+			JSON.stringify({
+				removed: removedNames,
+				count: removed,
+				reclaimed_chars: totalWaste,
+			}),
+		);
 	} else {
 		console.log(
 			`\n  ${bold(`Removed ${removed} skills`)} ${dim("·")} ${bold(`${(totalWaste / 1000).toFixed(1)}K`)} ${dim("reclaimed")}\n`,

--- a/packages/cli/src/commands/scan.ts
+++ b/packages/cli/src/commands/scan.ts
@@ -3,24 +3,13 @@ import { join } from "node:path";
 import { getDb } from "../db/schema";
 import { performScan } from "../scanner/auto-scan";
 import { countAllSessions } from "../scanner/index";
-import { getDetectedAgents, scanInstalledSkills } from "../scanner/skills";
+import {
+	detectSkillSource,
+	getDetectedAgents,
+	scanInstalledSkills,
+} from "../scanner/skills";
 import { parseAgentFilter } from "../tui/args";
 import { bold, cyan, dim } from "../tui/colors";
-
-function detectSource(skillPath: string): "skills.sh" | "manual" {
-	const metaDir = join(skillPath, ".skills");
-	if (existsSync(metaDir)) return "skills.sh";
-
-	const skillMd = join(skillPath, "SKILL.md");
-	if (existsSync(skillMd)) {
-		try {
-			const entries = readdirSync(skillPath);
-			if (entries.includes(".git") || entries.includes(".gitmodules"))
-				return "skills.sh";
-		} catch {}
-	}
-	return "manual";
-}
 
 export async function runScan(): Promise<void> {
 	const args = process.argv.slice(3);
@@ -48,15 +37,18 @@ export async function runScan(): Promise<void> {
 
 	let skillsShCount = 0;
 	let manualCount = 0;
+	let pluginCount = 0;
 
 	for (const skill of skills) {
-		const source = detectSource(skill.path);
+		const source = detectSkillSource(skill);
 		if (source === "skills.sh") skillsShCount++;
-		else manualCount++;
+		else if (source === "manual") manualCount++;
+		else pluginCount++;
 	}
 
 	const parts: string[] = [];
 	if (skillsShCount > 0) parts.push(`${skillsShCount} via skills.sh`);
+	if (pluginCount > 0) parts.push(`${pluginCount} via plugins`);
 	if (manualCount > 0) parts.push(`${manualCount} manual`);
 
 	if (!quiet)

--- a/packages/cli/src/scanner/auto-scan.ts
+++ b/packages/cli/src/scanner/auto-scan.ts
@@ -5,7 +5,11 @@ import { basename, join } from "node:path";
 import { deduplicateInvocations, upsertInstalledSkill } from "../db/queries";
 import type { InstalledSkill } from "../types";
 import { isSkillName, scanAllSessions } from "./index";
-import { getDetectedAgents, scanInstalledSkills } from "./skills";
+import {
+	detectSkillSource,
+	getDetectedAgents,
+	scanInstalledSkills,
+} from "./skills";
 
 export function buildKnownSkills(
 	skills: InstalledSkill[],
@@ -56,20 +60,6 @@ export function buildKnownSkills(
 	return knownSkills;
 }
 
-function detectSource(skillPath: string): "skills.sh" | "manual" {
-	const metaDir = join(skillPath, ".skills");
-	if (existsSync(metaDir)) return "skills.sh";
-
-	const skillMd = join(skillPath, "SKILL.md");
-	if (existsSync(skillMd)) {
-		try {
-			const entries = readdirSync(skillPath);
-			if (entries.includes(".git") || entries.includes(".gitmodules"))
-				return "skills.sh";
-		} catch {}
-	}
-	return "manual";
-}
 
 export async function performScan(
 	db: Database,
@@ -89,7 +79,7 @@ export async function performScan(
 	const skills = scanInstalledSkills(agentFilter);
 
 	for (const skill of skills) {
-		const source = detectSource(skill.path);
+		const source = detectSkillSource(skill);
 		upsertInstalledSkill(
 			db,
 			skill.name,

--- a/packages/cli/src/scanner/skills.ts
+++ b/packages/cli/src/scanner/skills.ts
@@ -16,21 +16,46 @@ function getSupportedAgents(): AgentDef[] {
 	const xdgConfig = process.env.XDG_CONFIG_HOME || join(home, ".config");
 
 	const agents: AgentDef[] = [
-		{ agent: "Claude Code", id: "claude", dirs: [join(home, ".claude", "skills")] },
+		{
+			agent: "Claude Code",
+			id: "claude",
+			dirs: [join(home, ".claude", "skills")],
+		},
 		{ agent: "Cursor", id: "cursor", dirs: [join(home, ".cursor", "skills")] },
 		{ agent: "Codex", id: "codex", dirs: [join(home, ".codex", "skills")] },
-		{ agent: "Gemini CLI", id: "gemini", dirs: [join(home, ".gemini", "skills")] },
-		{ agent: "Windsurf", id: "windsurf", dirs: [join(home, ".codeium", "windsurf", "skills")] },
-		{ agent: "Amp", id: "amp", dirs: [join(xdgData, "amp", "skills"), join(home, ".amp", "skills")] },
-		{ agent: "Continue", id: "continue", dirs: [join(home, ".continue", "skills")] },
+		{
+			agent: "Gemini CLI",
+			id: "gemini",
+			dirs: [join(home, ".gemini", "skills")],
+		},
+		{
+			agent: "Windsurf",
+			id: "windsurf",
+			dirs: [join(home, ".codeium", "windsurf", "skills")],
+		},
+		{
+			agent: "Amp",
+			id: "amp",
+			dirs: [join(xdgData, "amp", "skills"), join(home, ".amp", "skills")],
+		},
+		{
+			agent: "Continue",
+			id: "continue",
+			dirs: [join(home, ".continue", "skills")],
+		},
 		{ agent: "Goose", id: "goose", dirs: [join(xdgConfig, "goose", "skills")] },
 		{ agent: "Kiro", id: "kiro", dirs: [join(home, ".kiro", "skills")] },
 		{ agent: "Roo Code", id: "roo", dirs: [join(home, ".roo", "skills")] },
-		{ agent: "Antigravity", id: "antigravity", dirs: [join(home, ".gemini", "antigravity", "skills")] },
+		{
+			agent: "Antigravity",
+			id: "antigravity",
+			dirs: [join(home, ".gemini", "antigravity", "skills")],
+		},
 	];
 
 	if (os === "win32") {
-		const localAppData = process.env.LOCALAPPDATA || join(home, "AppData", "Local");
+		const localAppData =
+			process.env.LOCALAPPDATA || join(home, "AppData", "Local");
 		agents.push({
 			agent: "OpenCode",
 			id: "opencode",
@@ -52,10 +77,68 @@ function getSupportedAgents(): AgentDef[] {
 
 	const sharedDir = join(home, ".agents", "skills");
 	if (existsSync(sharedDir)) {
-		agents.push({ agent: "skills.sh (shared)", id: "shared", dirs: [sharedDir] });
+		agents.push({
+			agent: "skills.sh (shared)",
+			id: "shared",
+			dirs: [sharedDir],
+		});
 	}
 
 	return agents;
+}
+
+interface PluginInstall {
+	installPath?: string;
+	version?: string;
+}
+
+interface PluginManifest {
+	plugins?: Record<string, PluginInstall[]>;
+}
+
+function getClaudePluginSkillDirs(): Array<{ dir: string; source: string }> {
+	const manifestPath = join(
+		homedir(),
+		".claude",
+		"plugins",
+		"installed_plugins.json",
+	);
+	if (!existsSync(manifestPath)) return [];
+
+	let manifest: PluginManifest;
+	try {
+		manifest = JSON.parse(readFileSync(manifestPath, "utf-8"));
+	} catch {
+		return [];
+	}
+
+	const result: Array<{ dir: string; source: string }> = [];
+	for (const [pluginKey, installs] of Object.entries(manifest.plugins ?? {})) {
+		if (!Array.isArray(installs)) continue;
+		for (const install of installs) {
+			if (!install?.installPath) continue;
+			const dir = join(install.installPath, "skills");
+			if (existsSync(dir)) result.push({ dir, source: pluginKey });
+		}
+	}
+	return result;
+}
+
+export function detectSkillSource(skill: InstalledSkill): string {
+	if (skill.source) return skill.source;
+
+	const metaDir = join(skill.path, ".skills");
+	if (existsSync(metaDir)) return "skills.sh";
+
+	const skillMd = join(skill.path, "SKILL.md");
+	if (existsSync(skillMd)) {
+		try {
+			const entries = readdirSync(skill.path);
+			if (entries.includes(".git") || entries.includes(".gitmodules"))
+				return "skills.sh";
+		} catch {}
+	}
+	return "manual";
 }
 
 function parseYamlFrontmatter(content: string): Record<string, string> {
@@ -160,22 +243,35 @@ export function scanInstalledSkills(agentFilter?: string): InstalledSkill[] {
 	const seen = new Set<string>();
 	const agents = getSupportedAgents();
 
+	const addSkill = (skill: InstalledSkill): void => {
+		try {
+			const ino = statSync(skill.path).ino;
+			if (seen.has(`ino:${ino}`)) return;
+			seen.add(`ino:${ino}`);
+		} catch {}
+		if (seen.has(`name:${skill.name}`)) return;
+		seen.add(`name:${skill.name}`);
+		allSkills.push(skill);
+	};
+
 	for (const { agent, id, dirs } of agents) {
 		if (agentFilter && id !== agentFilter) continue;
 		for (const dir of dirs) {
 			const skills = scanSkillsDir(dir, agent);
 			if (skills.length === 0) continue;
 			for (const skill of skills) {
-				try {
-					const ino = statSync(skill.path).ino;
-					if (seen.has(`ino:${ino}`)) continue;
-					seen.add(`ino:${ino}`);
-				} catch {}
-				if (seen.has(`name:${skill.name}`)) continue;
-				seen.add(`name:${skill.name}`);
-				allSkills.push(skill);
+				addSkill(skill);
 			}
 			break;
+		}
+	}
+
+	if (!agentFilter || agentFilter === "claude") {
+		for (const { dir, source } of getClaudePluginSkillDirs()) {
+			for (const skill of scanSkillsDir(dir, "Claude Code")) {
+				skill.source = source;
+				addSkill(skill);
+			}
 		}
 	}
 

--- a/packages/cli/src/types/index.ts
+++ b/packages/cli/src/types/index.ts
@@ -5,6 +5,7 @@ export interface InstalledSkill {
 	size: number;
 	installedAt: string;
 	agent: string;
+	source?: string;
 }
 
 export interface SkillInvocation {


### PR DESCRIPTION
Closes #21

## What

`skillkit scan` (and `list`/`stats`/`health`/`prune`) now treat skills bundled inside Claude Code plugins as first-class, with their source tracked.

## How

- `~/.claude/plugins/installed_plugins.json` (v2 format) drives discovery, as suggested in the issue. This matters because the cache can hold several versions of a plugin (my machine has 4 cached figma versions); only the manifest's active `installPath` is scanned.
- Each plugin install's `skills/` dir goes through the same `scanSkillsDir` pipeline, tagged with the plugin key (e.g. `figma@claude-plugins-official`) as `source`. Dedupe by inode and name is shared with the regular scan, so a manually installed skill with the same name wins.
- New shared `detectSkillSource()` replaces the `detectSource` copies in `scan.ts` and `auto-scan.ts`; the plugin key persists to the existing `installed_skills.source` column.
- `skillkit list` shows a SOURCE column (`manual` / `skills.sh` / plugin name).
- `skillkit prune` excludes plugin-bundled skills from candidates with an explanatory note: deleting them from the cache breaks the plugin and they would be restored on update. They are managed via `/plugin`.

Scope note: the issue also mentions plugin `commands/` and `agents/`; this PR covers skills only, which is what the analytics pipeline tracks today.

## Verified (real machine, 2 plugins with bundled skills)

```
$ skillkit scan
  Found 19 skills (15 via plugins, 4 manual)

$ skillkit list | grep figma-use
  figma-use  ...  figma  686.8 KB   # path resolves to active 2.2.81, not older cached versions

$ sqlite3 ~/.skillkit/analytics.db "SELECT source, COUNT(*) FROM installed_skills GROUP BY source"
  codex@openai-codex|3
  figma@claude-plugins-official|12
  manual|175
  skills.sh|1

$ skillkit prune
  3 skills · 87.9K context reclaimable
  15 unused plugin-bundled skills skipped (managed via /plugin, would be restored on update)
```

- `bun test`: 25 pass / 7 fail, identical on clean main (pre-existing, environmental)
- `tsc --noEmit`: no new errors in changed files
- Part of the diff is Biome formatting applied to touched files (the junkNames array reflow in auto-scan.ts is formatting only)

cc @jvluyn who offered to test against a setup with ~15 plugin-bundled skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBRGWen5utt7WBNtBKdMtU