### PR TITLE
fix(scanner): stop counting agent tool calls as skill invocations

### DIFF
--- a/packages/cli/src/__tests__/codex-parser.test.ts
+++ b/packages/cli/src/__tests__/codex-parser.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { parseCodexSessionFile } from "../scanner/connectors/codex";
+
+function writeSession(lines: object[]): string {
+	const dir = mkdtempSync(join(tmpdir(), "skillkit-codex-"));
+	const file = join(dir, "rollout-test.jsonl");
+	writeFileSync(file, lines.map((l) => JSON.stringify(l)).join("\n"));
+	return file;
+}
+
+function fnCall(name: string, args = "{}") {
+	return {
+		timestamp: "2026-07-18T00:00:00.000Z",
+		type: "response_item",
+		payload: { type: "function_call", name, arguments: args },
+	};
+}
+
+describe("parseCodexSessionFile strict gate", () => {
+	it("ignores tool calls when knownSkills is empty", () => {
+		const file = writeSession([
+			fnCall("wait"),
+			fnCall("view_image"),
+			fnCall("firecrawl_search"),
+		]);
+		expect(parseCodexSessionFile(file)).toEqual([]);
+		expect(parseCodexSessionFile(file, new Set())).toEqual([]);
+	});
+
+	it("only counts calls matching a known skill", () => {
+		const file = writeSession([
+			fnCall("firecrawl_search"),
+			fnCall("get_goal"),
+			fnCall("hatch-pet"),
+		]);
+		const out = parseCodexSessionFile(file, new Set(["hatch-pet"]));
+		expect(out.map((i) => i.skillName)).toEqual(["hatch-pet"]);
+		expect(out[0]?.agent).toBe("codex");
+	});
+
+	it("always counts skills read via SKILL.md path in exec_command", () => {
+		const file = writeSession([
+			fnCall(
+				"exec_command",
+				JSON.stringify({
+					command: "cat /Users/x/.claude/skills/my-skill/SKILL.md",
+				}),
+			),
+		]);
+		const out = parseCodexSessionFile(file);
+		expect(out.map((i) => i.skillName)).toEqual(["my-skill"]);
+	});
+
+	it("filters codex internal tools even if present in knownSkills", () => {
+		const file = writeSession([fnCall("wait"), fnCall("update_plan")]);
+		expect(
+			parseCodexSessionFile(file, new Set(["wait", "update_plan"])),
+		).toEqual([]);
+	});
+});

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -1,6 +1,6 @@
 import {
-	getDailyUsage,
 	getCurrentStreak,
+	getDailyUsage,
 	getInstalledSkills,
 	getSkillStats,
 	getTopSkills,
@@ -8,12 +8,14 @@ import {
 } from "../db/queries";
 import { getDb } from "../db/schema";
 import { performScan } from "../scanner/auto-scan";
-import { scanAllSessions } from "../scanner/index";
 import { parseAgentFilter } from "../tui/args";
 import { bold, cyan, dim, green, red, yellow } from "../tui/colors";
 import { sparkline } from "../tui/sparkline";
 
-function getMostActiveDay(db: ReturnType<typeof getDb>, agent?: string): string {
+function getMostActiveDay(
+	db: ReturnType<typeof getDb>,
+	agent?: string,
+): string {
 	const agentClause = agent ? " WHERE agent = ?" : "";
 	const params = agent ? [agent] : [];
 	const row = db
@@ -49,7 +51,6 @@ function parseDays(args: string[]): number {
 	return 30;
 }
 
-
 export async function runStats(): Promise<void> {
 	const db = getDb();
 	const args = process.argv.slice(3);
@@ -69,15 +70,20 @@ export async function runStats(): Promise<void> {
 				console.log(JSON.stringify({ error: "no_skills_found" }));
 			} else {
 				console.log(`\n  ${yellow("No skills found.")}`);
-				console.log(`  ${dim("Skills will be scanned automatically on next run.")}\n`);
+				console.log(
+					`  ${dim("Skills will be scanned automatically on next run.")}\n`,
+				);
 			}
 			return;
 		}
 	} else {
 		if (!isJson) console.log("\n  Scanning sessions...");
-		const newCount = await scanAllSessions(db, new Set(), agentFilter);
-		if (newCount > 0 && !isJson) {
-			console.log(`  Found ${newCount} new invocations.\n`);
+		const refresh = await performScan(db, {
+			agentFilter,
+			includeCommands: true,
+		});
+		if (refresh.invocationCount > 0 && !isJson) {
+			console.log(`  Found ${refresh.invocationCount} new invocations.\n`);
 		}
 	}
 
@@ -94,7 +100,12 @@ export async function runStats(): Promise<void> {
 	}
 
 	const showAll = process.argv.includes("--all");
-	const topSkills = getTopSkills(db, days, showAll ? undefined : 10, agentFilter);
+	const topSkills = getTopSkills(
+		db,
+		days,
+		showAll ? undefined : 10,
+		agentFilter,
+	);
 	const activeDay = getMostActiveDay(db, agentFilter);
 
 	if (isJson) {
@@ -106,7 +117,11 @@ export async function runStats(): Promise<void> {
 			unique_skills: stats.unique_skills,
 			most_active_day: activeDay,
 			streak: { current: streak.current, longest: streak.longest },
-			velocity: { this_week: velocity.thisWeek, last_week: velocity.lastWeek, change_pct: velocity.change },
+			velocity: {
+				this_week: velocity.thisWeek,
+				last_week: velocity.lastWeek,
+				change_pct: velocity.change,
+			},
 			top_skills: topSkills.map((skill) => {
 				const daily = getDailyUsage(db, skill.skill_name, days, agentFilter);
 				return {
@@ -121,7 +136,11 @@ export async function runStats(): Promise<void> {
 	}
 
 	const label =
-		days === 30 ? "last 30 days" : days === 7 ? "last 7 days" : `last ${days} days`;
+		days === 30
+			? "last 30 days"
+			: days === 7
+				? "last 7 days"
+				: `last ${days} days`;
 
 	console.log(`\n  ${bold("SKILL-KIT ANALYTICS")} ${dim(`(${label})`)}\n`);
 	console.log(`  Total invocations: ${bold(String(stats.total))}`);
@@ -132,7 +151,9 @@ export async function runStats(): Promise<void> {
 	const velocity = getWeeklyVelocity(db, agentFilter);
 
 	if (streak.current > 0) {
-		console.log(`  Current streak:    ${bold(`${streak.current} days`)} ${streak.current >= 7 ? "🔥" : ""}`);
+		console.log(
+			`  Current streak:    ${bold(`${streak.current} days`)} ${streak.current >= 7 ? "🔥" : ""}`,
+		);
 		console.log(`  Longest streak:    ${bold(`${streak.longest} days`)}`);
 	}
 
@@ -143,7 +164,9 @@ export async function runStats(): Promise<void> {
 				: velocity.change < 0
 					? red(`${velocity.change.toFixed(0)}%`)
 					: dim("—");
-		console.log(`  This week:         ${bold(`$${velocity.thisWeek.toFixed(2)}`)} ${dim("vs last")} $${velocity.lastWeek.toFixed(2)} (${changeStr})`);
+		console.log(
+			`  This week:         ${bold(`$${velocity.thisWeek.toFixed(2)}`)} ${dim("vs last")} $${velocity.lastWeek.toFixed(2)} (${changeStr})`,
+		);
 	}
 
 	if (streak.current > 0 || velocity.thisWeek > 0) console.log();

--- a/packages/cli/src/db/schema.ts
+++ b/packages/cli/src/db/schema.ts
@@ -43,8 +43,23 @@ export function getDb(): Database {
 	`);
 	try {
 		db.run("ALTER TABLE skill_invocations ADD COLUMN agent TEXT");
-		db.run("UPDATE skill_invocations SET agent = 'claude' WHERE agent IS NULL AND session_id IS NOT NULL AND session_id NOT LIKE 'oc:%'");
-		db.run("UPDATE skill_invocations SET agent = 'opencode' WHERE agent IS NULL AND session_id LIKE 'oc:%'");
+	} catch {}
+	try {
+		db.run(
+			"UPDATE skill_invocations SET agent = 'opencode' WHERE (agent IS NULL OR agent = '') AND session_id LIKE 'oc:%'",
+		);
+		db.run(
+			"UPDATE skill_invocations SET agent = 'codex' WHERE (agent IS NULL OR agent = '') AND session_id LIKE 'codex:%'",
+		);
+		db.run(
+			"UPDATE skill_invocations SET agent = 'cursor' WHERE (agent IS NULL OR agent = '') AND session_id LIKE 'cursor:%'",
+		);
+		db.run(
+			"UPDATE skill_invocations SET agent = 'gemini' WHERE (agent IS NULL OR agent = '') AND session_id LIKE 'gemini:%'",
+		);
+		db.run(
+			"UPDATE skill_invocations SET agent = 'claude' WHERE (agent IS NULL OR agent = '') AND session_id IS NOT NULL",
+		);
 	} catch {}
 	db.run(
 		"CREATE INDEX IF NOT EXISTS idx_invocations_agent ON skill_invocations(agent)",
@@ -89,11 +104,15 @@ export function getDb(): Database {
 
 function deduplicateInvocations(db: Database): void {
 	try {
-		db.run(`DELETE FROM skill_invocations WHERE skill_name LIKE 'mcp_%' OR skill_name LIKE 'mcp__%' OR skill_name = 'update_plan'`);
+		db.run(
+			`DELETE FROM skill_invocations WHERE skill_name LIKE 'mcp_%' OR skill_name LIKE 'mcp__%' OR skill_name = 'update_plan'`,
+		);
 
-		const row = db.query<{ dupes: number }, []>(
-			`SELECT COUNT(*) - COUNT(DISTINCT skill_name || '::' || REPLACE(timestamp, SUBSTR(timestamp, -5, 4), '')) as dupes FROM skill_invocations`
-		).get();
+		const row = db
+			.query<{ dupes: number }, []>(
+				`SELECT COUNT(*) - COUNT(DISTINCT skill_name || '::' || REPLACE(timestamp, SUBSTR(timestamp, -5, 4), '')) as dupes FROM skill_invocations`,
+			)
+			.get();
 		if (row && row.dupes > 0) {
 			db.run(`
 				DELETE FROM skill_invocations WHERE rowid NOT IN (
@@ -102,5 +121,7 @@ function deduplicateInvocations(db: Database): void {
 				)
 			`);
 		}
-	} catch { /* empty */ }
+	} catch {
+		/* empty */
+	}
 }

--- a/packages/cli/src/scanner/auto-scan.ts
+++ b/packages/cli/src/scanner/auto-scan.ts
@@ -3,8 +3,58 @@ import { existsSync, readdirSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
 import { deduplicateInvocations, upsertInstalledSkill } from "../db/queries";
+import type { InstalledSkill } from "../types";
 import { isSkillName, scanAllSessions } from "./index";
 import { getDetectedAgents, scanInstalledSkills } from "./skills";
+
+export function buildKnownSkills(
+	skills: InstalledSkill[],
+	includeCommands: boolean,
+): Set<string> {
+	const knownSkills = new Set<string>();
+	for (const skill of skills) {
+		knownSkills.add(skill.name);
+		knownSkills.add(basename(skill.path));
+	}
+
+	const localSkillsDir = join(process.cwd(), ".claude", "skills");
+	if (existsSync(localSkillsDir)) {
+		try {
+			for (const e of readdirSync(localSkillsDir)) {
+				try {
+					if (statSync(join(localSkillsDir, e)).isDirectory()) {
+						knownSkills.add(e);
+					}
+				} catch {}
+			}
+		} catch {}
+	}
+
+	if (includeCommands) {
+		const commandDirs = [
+			join(process.cwd(), ".claude", "commands"),
+			join(homedir(), ".claude", "commands"),
+		];
+		for (const dir of commandDirs) {
+			if (!existsSync(dir)) continue;
+			try {
+				for (const e of readdirSync(dir)) {
+					if (e.endsWith(".md")) {
+						knownSkills.add(e.slice(0, -3));
+					} else {
+						try {
+							if (statSync(join(dir, e)).isDirectory()) {
+								knownSkills.add(e);
+							}
+						} catch {}
+					}
+				}
+			} catch {}
+		}
+	}
+
+	return knownSkills;
+}
 
 function detectSource(skillPath: string): "skills.sh" | "manual" {
 	const metaDir = join(skillPath, ".skills");
@@ -54,69 +104,75 @@ export async function performScan(
 		return { skillCount: 0, invocationCount: 0 };
 	}
 
-	const localSkillsDir = join(process.cwd(), ".claude", "skills");
-	const knownSkills = new Set<string>();
-	for (const skill of skills) {
-		knownSkills.add(skill.name);
-		knownSkills.add(basename(skill.path));
-	}
-
-	if (existsSync(localSkillsDir)) {
-		try {
-			for (const e of readdirSync(localSkillsDir)) {
-				try {
-					if (statSync(join(localSkillsDir, e)).isDirectory()) {
-						knownSkills.add(e);
-					}
-				} catch {}
-			}
-		} catch {}
-	}
-
-	if (includeCommands) {
-		const commandDirs = [
-			join(process.cwd(), ".claude", "commands"),
-			join(homedir(), ".claude", "commands"),
-		];
-		for (const dir of commandDirs) {
-			if (!existsSync(dir)) continue;
-			try {
-				for (const e of readdirSync(dir)) {
-					if (e.endsWith(".md")) {
-						knownSkills.add(e.slice(0, -3));
-					} else {
-						try {
-							if (statSync(join(dir, e)).isDirectory()) {
-								knownSkills.add(e);
-							}
-						} catch {}
-					}
-				}
-			} catch {}
-		}
-	}
+	const knownSkills = buildKnownSkills(skills, includeCommands);
 
 	deduplicateInvocations(db);
 
 	db.run(
-		`DELETE FROM skill_invocations WHERE skill_name LIKE 'mcp__%' OR skill_name LIKE 'mcp_%'`
+		`DELETE FROM skill_invocations WHERE skill_name LIKE 'mcp__%' OR skill_name LIKE 'mcp_%'`,
 	);
 	const junkNames = [
-		"Read", "Write", "Edit", "MultiEdit", "Bash", "Glob", "Grep",
-		"WebSearch", "WebFetch", "TodoRead", "TodoWrite", "Task", "Agent",
-		"Skill", "LSP", "NotebookEdit", "AskFollowupQuestion",
-		"AttemptCompletion", "SearchReplace", "InsertCodeBlock",
-		"ReadImages", "ExecuteCommand", "ListFiles", "SearchFiles",
-		"ReadFile", "WriteFile", "ReplaceInFile", "ListCodeDefinitionNames",
-		"BrowserAction", "UseMcp", "shell", "shell_command",
-		"update_plan", "create_plan", "read_file", "write_file",
-		"execute_command", "spawn_agent", "write_stdin",
+		"Read",
+		"Write",
+		"Edit",
+		"MultiEdit",
+		"Bash",
+		"Glob",
+		"Grep",
+		"WebSearch",
+		"WebFetch",
+		"TodoRead",
+		"TodoWrite",
+		"Task",
+		"Agent",
+		"Skill",
+		"LSP",
+		"NotebookEdit",
+		"AskFollowupQuestion",
+		"AttemptCompletion",
+		"SearchReplace",
+		"InsertCodeBlock",
+		"ReadImages",
+		"ExecuteCommand",
+		"ListFiles",
+		"SearchFiles",
+		"ReadFile",
+		"WriteFile",
+		"ReplaceInFile",
+		"ListCodeDefinitionNames",
+		"BrowserAction",
+		"UseMcp",
+		"shell",
+		"shell_command",
+		"update_plan",
+		"create_plan",
+		"read_file",
+		"write_file",
+		"execute_command",
+		"spawn_agent",
+		"write_stdin",
 		"multi_tool_use.parallel",
 	];
 	const placeholders = junkNames.map(() => "?").join(",");
-	db.run(`DELETE FROM skill_invocations WHERE skill_name IN (${placeholders})`, junkNames);
+	db.run(
+		`DELETE FROM skill_invocations WHERE skill_name IN (${placeholders})`,
+		junkNames,
+	);
 
 	const newInvocations = await scanAllSessions(db, knownSkills, agentFilter);
+
+	if (!agentFilter) {
+		const cleanupAllowlist = includeCommands
+			? knownSkills
+			: buildKnownSkills(skills, true);
+		db.run(
+			`DELETE FROM skill_invocations
+				WHERE agent IN ('codex', 'cursor', 'gemini')
+					AND skill_name NOT IN (SELECT name FROM installed_skills)
+					AND skill_name NOT IN (SELECT value FROM json_each(?))`,
+			[JSON.stringify([...cleanupAllowlist])],
+		);
+	}
 
 	return { skillCount: skills.length, invocationCount: newInvocations };
 }

--- a/packages/cli/src/scanner/connectors/claude.ts
+++ b/packages/cli/src/scanner/connectors/claude.ts
@@ -19,12 +19,10 @@ function extractSkillName(block: ToolUseBlock): string | null {
 	return null;
 }
 
-const COMMAND_NAME_RE = /<command-name>\/?([a-zA-Z][\w-]*(?::[\w-]*)*)<\/command-name>/g;
+const COMMAND_NAME_RE =
+	/<command-name>\/?([a-zA-Z][\w-]*(?::[\w-]*)*)<\/command-name>/g;
 
-function extractCommandNames(
-	text: string,
-	knownSkills: Set<string>,
-): string[] {
+function extractCommandNames(text: string, knownSkills: Set<string>): string[] {
 	const names: string[] = [];
 	let match: RegExpExecArray | null;
 	while ((match = COMMAND_NAME_RE.exec(text)) !== null) {
@@ -90,7 +88,12 @@ export function parseSessionFile(
 								.join("\n")
 						: "";
 			for (const name of extractCommandNames(text, knownSkills)) {
-				results.push({ skillName: name, timestamp, sessionId, agent: "claude" });
+				results.push({
+					skillName: name,
+					timestamp,
+					sessionId,
+					agent: "claude",
+				});
 			}
 			continue;
 		}
@@ -111,7 +114,7 @@ export function parseSessionFile(
 			) {
 				const skillName = extractSkillName(block as unknown as ToolUseBlock);
 				if (skillName) {
-					results.push({ skillName, timestamp, sessionId });
+					results.push({ skillName, timestamp, sessionId, agent: "claude" });
 				}
 			}
 		}

--- a/packages/cli/src/scanner/connectors/codex.ts
+++ b/packages/cli/src/scanner/connectors/codex.ts
@@ -11,10 +11,25 @@ const CODEX_INTERNAL_TOOLS = new Set([
 	"write_stdin",
 	"multi_tool_use.parallel",
 	"update_plan",
+	"view_image",
+	"wait",
+	"wait_agent",
+	"js",
+	"click",
+	"get_goal",
+	"get_app_state",
+	"close_agent",
+	"send_message",
+	"update_goal",
+	"create_goal",
 ]);
 
 function isInternalTool(name: string): boolean {
-	return CODEX_INTERNAL_TOOLS.has(name) || name.startsWith("mcp__") || name.startsWith("mcp_");
+	return (
+		CODEX_INTERNAL_TOOLS.has(name) ||
+		name.startsWith("mcp__") ||
+		name.startsWith("mcp_")
+	);
 }
 
 const SKILL_PATH_RE = /skills\/([^/]+)\/SKILL\.md/;
@@ -83,7 +98,7 @@ export function parseCodexSessionFile(
 
 				if (isInternalTool(name)) continue;
 
-				if (knownSkills.size === 0 || knownSkills.has(name)) {
+				if (knownSkills.has(name)) {
 					results.push({
 						skillName: name,
 						timestamp,
@@ -99,18 +114,10 @@ export function parseCodexSessionFile(
 					| undefined;
 				if (!Array.isArray(content)) continue;
 				for (const block of content) {
-					if (
-						block.type === "tool_use" ||
-						block.type === "function_call"
-					) {
-						const name = (block.name ?? block.skill) as
-							| string
-							| undefined;
+					if (block.type === "tool_use" || block.type === "function_call") {
+						const name = (block.name ?? block.skill) as string | undefined;
 						if (!name || isInternalTool(name)) continue;
-						if (
-							knownSkills.size === 0 ||
-							knownSkills.has(name)
-						) {
+						if (knownSkills.has(name)) {
 							results.push({
 								skillName: name,
 								timestamp,

--- a/packages/cli/src/scanner/connectors/cursor.ts
+++ b/packages/cli/src/scanner/connectors/cursor.ts
@@ -48,16 +48,12 @@ export function parseCursorSessionFile(
 					block.type === "tool_use" &&
 					(block as { name?: string }).name === "Skill"
 				) {
-					const input = (block as { input?: Record<string, unknown> })
-						.input;
+					const input = (block as { input?: Record<string, unknown> }).input;
 					if (!input) continue;
-					const skillName = (input.skill ??
-						input.name ??
-						input.skillName) as string | undefined;
-					if (
-						skillName &&
-						(knownSkills.size === 0 || knownSkills.has(skillName))
-					) {
+					const skillName = (input.skill ?? input.name ?? input.skillName) as
+						| string
+						| undefined;
+					if (skillName && knownSkills.has(skillName)) {
 						results.push({
 							skillName,
 							timestamp: new Date().toISOString(),

--- a/packages/cli/src/scanner/connectors/gemini.ts
+++ b/packages/cli/src/scanner/connectors/gemini.ts
@@ -46,12 +46,18 @@ export function parseGeminiSessionFile(
 	if (!Array.isArray(session.messages)) return results;
 
 	for (const msg of session.messages) {
-		const timestamp = msg.timestamp ?? session.startTime ?? new Date().toISOString();
+		const timestamp =
+			msg.timestamp ?? session.startTime ?? new Date().toISOString();
 
 		const calls = msg.toolCalls ?? msg.functionCalls ?? [];
 		for (const call of calls) {
-			if (call.name && (knownSkills.size === 0 || knownSkills.has(call.name))) {
-				results.push({ skillName: call.name, timestamp, sessionId, agent: "gemini" });
+			if (call.name && knownSkills.has(call.name)) {
+				results.push({
+					skillName: call.name,
+					timestamp,
+					sessionId,
+					agent: "gemini",
+				});
 			}
 		}
 
@@ -61,7 +67,12 @@ export function parseGeminiSessionFile(
 			while ((match = skillRe.exec(msg.content)) !== null) {
 				const name = match[1]!;
 				if (knownSkills.has(name)) {
-					results.push({ skillName: name, timestamp, sessionId, agent: "gemini" });
+					results.push({
+						skillName: name,
+						timestamp,
+						sessionId,
+						agent: "gemini",
+					});
 				}
 			}
 		}


### PR DESCRIPTION
## Problem

`skillkit` was recording raw agent tool calls as skill invocations. On a real DB, 10,122 codex rows contained only ~449 actual skills (~4%); the rest were harness tools (`view_image` x1917, `wait` x1682, `js`, `click`, goal/agent tools) and unprefixed MCP tool names (`firecrawl_search` x1094, `_run_sql`, ...).

Two combined causes:

1. **Permissive fallback in connectors.** Codex, Gemini, and Cursor parsers accepted every tool call when `knownSkills` was empty (`knownSkills.size === 0 || knownSkills.has(name)`).
2. **stats.ts bypassed the filter.** It called `scanAllSessions(db, new Set(), agentFilter)`, so every `skillkit stats` run hit that fallback and wrote junk. The April fix (daeacbf) covered scan/auto-scan but left this path open.

Bonus finding: `claude.ts`'s Skill-tool detection omitted the `agent` field, accumulating 545 rows with empty agent that the old migration (which only matched `agent IS NULL`) never repaired.

## Fix

- Strict gate: a tool-call name only counts when it matches a known skill. `SKILL.md` path detection in `exec_command` still counts unconditionally (strong evidence).
- `stats.ts` now runs `performScan` (proper `knownSkills` via the new shared `buildKnownSkills()` + cleanup) instead of scanning with an empty set.
- `CODEX_INTERNAL_TOOLS` extended with observed harness tools.
- **Self-healing DBs**: every unfiltered scan purges codex/cursor/gemini rows whose name is neither a known skill/command nor recorded in `installed_skills` (which retains uninstalled skills, protecting their history). Existing polluted DBs fix themselves on the next `skillkit scan` or `stats`, no manual action.
- Agent backfill migration handles `NULL` and `''` by session-id prefix (`oc:`, `codex:`, `cursor:`, `gemini:`, else claude), in its own try block so the `ALTER TABLE` throw on existing DBs no longer skips it.

## Verified (real DB)

```
before: 11,851 invocations (codex 10,122 / 299 names, agent-less 545)
after one scan: 2,162 invocations
  claude 1,657 (545 repaired rows reattributed)
  codex    449 (only real skills: last30days, hatch-pet, agent-browser, ...)
  cursor    42
  opencode  14
```

- Parser fixture tests: 4 new, all pass. Full suite: same 7 pre-existing failures as clean main, no new ones.
- Follow-up `skillkit stats` run confirmed zero junk reintroduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBRGWen5utt7WBNtBKdMtU