### PR TITLE
feat(scanner): incremental scan cache, progress counter, and --full flag

### DIFF
--- a/packages/cli/src/__tests__/scan-cache.test.ts
+++ b/packages/cli/src/__tests__/scan-cache.test.ts
@@ -1,0 +1,82 @@
+import { Database } from "bun:sqlite";
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, utimesSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { ScanCache } from "../scanner/scan-cache";
+
+function tempFile(content = "x"): string {
+	const dir = mkdtempSync(join(tmpdir(), "skillkit-cache-"));
+	const file = join(dir, "session.jsonl");
+	writeFileSync(file, content);
+	return file;
+}
+
+describe("ScanCache", () => {
+	it("skips unchanged files on the second scan", () => {
+		const db = new Database(":memory:");
+		const file = tempFile();
+
+		const first = new ScanCache(db, { salt: "s1" });
+		expect(first.shouldSkip(file)).toBe(false);
+		first.flush();
+
+		const second = new ScanCache(db, { salt: "s1" });
+		expect(second.shouldSkip(file)).toBe(true);
+	});
+
+	it("rescans when the file changes", () => {
+		const db = new Database(":memory:");
+		const file = tempFile();
+
+		const first = new ScanCache(db, { salt: "s1" });
+		first.shouldSkip(file);
+		first.flush();
+
+		writeFileSync(file, "modified content");
+		const second = new ScanCache(db, { salt: "s1" });
+		expect(second.shouldSkip(file)).toBe(false);
+	});
+
+	it("rescans when only mtime changes", () => {
+		const db = new Database(":memory:");
+		const file = tempFile();
+
+		const first = new ScanCache(db, { salt: "s1" });
+		first.shouldSkip(file);
+		first.flush();
+
+		const future = new Date(Date.now() + 5000);
+		utimesSync(file, future, future);
+		const second = new ScanCache(db, { salt: "s1" });
+		expect(second.shouldSkip(file)).toBe(false);
+	});
+
+	it("invalidates everything when the skills salt changes", () => {
+		const db = new Database(":memory:");
+		const file = tempFile();
+
+		const first = new ScanCache(db, { salt: "s1" });
+		first.shouldSkip(file);
+		first.flush();
+
+		const second = new ScanCache(db, { salt: "s2" });
+		expect(second.shouldSkip(file)).toBe(false);
+	});
+
+	it("force mode rescans but rebuilds the cache", () => {
+		const db = new Database(":memory:");
+		const file = tempFile();
+
+		const first = new ScanCache(db, { salt: "s1" });
+		first.shouldSkip(file);
+		first.flush();
+
+		const forced = new ScanCache(db, { salt: "s1", force: true });
+		expect(forced.shouldSkip(file)).toBe(false);
+		forced.flush();
+
+		const after = new ScanCache(db, { salt: "s1" });
+		expect(after.shouldSkip(file)).toBe(true);
+	});
+});

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -34,6 +34,7 @@ function printHelp(): void {
 
   ${bold("FLAGS")}
     ${dim("scan")}  ${cyan("--include-commands")}  Also track slash commands (not just skills)
+    ${dim("scan")}  ${cyan("--full")}              Re-index every session (ignore incremental cache)
     ${dim("stats")} ${cyan("--days N")}             Time range in days (default: 30)
     ${dim("stats")} ${cyan("--all")}               Show all skills, not just top 10
     ${dim("stats")} ${cyan("--json")}              JSON output

--- a/packages/cli/src/commands/scan.ts
+++ b/packages/cli/src/commands/scan.ts
@@ -15,6 +15,7 @@ export async function runScan(): Promise<void> {
 	const args = process.argv.slice(3);
 	const includeCommands = args.includes("--include-commands");
 	const quiet = args.includes("--quiet");
+	const force = args.includes("--full");
 	const agentFilter = parseAgentFilter(args);
 	const db = getDb();
 
@@ -76,7 +77,14 @@ export async function runScan(): Promise<void> {
 		} catch {}
 	}
 
-	const result = await performScan(db, { includeCommands, agentFilter });
+	const startedAt = performance.now();
+	const result = await performScan(db, {
+		includeCommands,
+		agentFilter,
+		quiet,
+		force,
+	});
+	const elapsed = ((performance.now() - startedAt) / 1000).toFixed(1);
 
 	const sessionCount = countAllSessions(agentFilter);
 	const totalRow = db
@@ -88,7 +96,7 @@ export async function runScan(): Promise<void> {
 
 	if (!quiet) {
 		console.log(
-			`  ${dim("Indexed")} ${bold(String(sessionCount))} ${dim("sessions")} ${cyan("·")} ${bold(totalInvocations.toLocaleString())} ${dim("invocations")}`,
+			`  ${dim("Indexed")} ${bold(String(sessionCount))} ${dim("sessions")} ${cyan("·")} ${bold(totalInvocations.toLocaleString())} ${dim("invocations")} ${dim(`(${elapsed}s)`)}`,
 		);
 
 		if (result.invocationCount > 0) {

--- a/packages/cli/src/commands/stats.ts
+++ b/packages/cli/src/commands/stats.ts
@@ -62,7 +62,7 @@ export async function runStats(): Promise<void> {
 
 	if (installedSkills.length === 0) {
 		if (!isJson) console.log("\n  First run detected, scanning skills...");
-		const result = await performScan(db, { agentFilter });
+		const result = await performScan(db, { agentFilter, quiet: isJson });
 		if (result.skillCount > 0) {
 			if (!isJson) console.log(`  Found ${result.skillCount} skills.\n`);
 		} else {
@@ -81,6 +81,7 @@ export async function runStats(): Promise<void> {
 		const refresh = await performScan(db, {
 			agentFilter,
 			includeCommands: true,
+			quiet: isJson,
 		});
 		if (refresh.invocationCount > 0 && !isJson) {
 			console.log(`  Found ${refresh.invocationCount} new invocations.\n`);

--- a/packages/cli/src/scanner/auto-scan.ts
+++ b/packages/cli/src/scanner/auto-scan.ts
@@ -60,16 +60,21 @@ export function buildKnownSkills(
 	return knownSkills;
 }
 
-
 export async function performScan(
 	db: Database,
 	options: {
 		includeCommands?: boolean;
 		quiet?: boolean;
 		agentFilter?: string;
+		force?: boolean;
 	} = {},
 ): Promise<{ skillCount: number; invocationCount: number }> {
-	const { includeCommands = false, quiet = false, agentFilter } = options;
+	const {
+		includeCommands = false,
+		quiet = false,
+		agentFilter,
+		force = false,
+	} = options;
 
 	const agents = getDetectedAgents(agentFilter);
 	if (agents.length === 0) {
@@ -149,7 +154,19 @@ export async function performScan(
 		junkNames,
 	);
 
-	const newInvocations = await scanAllSessions(db, knownSkills, agentFilter);
+	const saltSkills = agentFilter ? scanInstalledSkills() : skills;
+	const cacheSalt = Bun.hash(
+		saltSkills
+			.map((s) => s.name)
+			.sort()
+			.join("\n"),
+	).toString(16);
+
+	const newInvocations = await scanAllSessions(db, knownSkills, agentFilter, {
+		force,
+		quiet,
+		cacheSalt,
+	});
 
 	if (!agentFilter) {
 		const cleanupAllowlist = includeCommands

--- a/packages/cli/src/scanner/connectors/claude.ts
+++ b/packages/cli/src/scanner/connectors/claude.ts
@@ -2,8 +2,10 @@ import type { Database } from "bun:sqlite";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
+import type { ProgressReporter } from "../../tui/progress";
 import type { Invocation } from "../index";
 import { recordNewInvocations } from "../index";
+import type { ScanCache } from "../scan-cache";
 
 interface ToolUseBlock {
 	type: "tool_use";
@@ -139,6 +141,8 @@ export async function scanClaudeSessions(
 	db: Database,
 	trackedSet: Set<string>,
 	knownSkills: Set<string> = new Set(),
+	cache?: ScanCache,
+	progress?: ProgressReporter,
 ): Promise<number> {
 	const projectsDir = join(homedir(), ".claude", "projects");
 	if (!existsSync(projectsDir)) return 0;
@@ -151,10 +155,18 @@ export async function scanClaudeSessions(
 	}
 
 	let total = 0;
+	let done = 0;
 	for (const file of files) {
+		done++;
+		if (cache?.shouldSkip(file)) {
+			progress?.update(done, files.length);
+			continue;
+		}
 		const invocations = parseSessionFile(file, knownSkills);
 		total += recordNewInvocations(db, trackedSet, invocations);
+		progress?.update(done, files.length);
 	}
+	progress?.finish();
 
 	return total;
 }

--- a/packages/cli/src/scanner/connectors/codex.ts
+++ b/packages/cli/src/scanner/connectors/codex.ts
@@ -2,8 +2,10 @@ import type { Database } from "bun:sqlite";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
+import type { ProgressReporter } from "../../tui/progress";
 import type { Invocation } from "../index";
 import { recordNewInvocations } from "../index";
+import type { ScanCache } from "../scan-cache";
 
 const CODEX_INTERNAL_TOOLS = new Set([
 	"exec_command",
@@ -150,6 +152,8 @@ export async function scanCodexSessions(
 	db: Database,
 	trackedSet: Set<string>,
 	knownSkills: Set<string> = new Set(),
+	cache?: ScanCache,
+	progress?: ProgressReporter,
 ): Promise<number> {
 	const sessionsDir = join(homedir(), ".codex", "sessions");
 	if (!existsSync(sessionsDir)) return 0;
@@ -161,10 +165,18 @@ export async function scanCodexSessions(
 	}
 
 	let total = 0;
+	let done = 0;
 	for (const file of files) {
+		done++;
+		if (cache?.shouldSkip(file)) {
+			progress?.update(done, files.length);
+			continue;
+		}
 		const invocations = parseCodexSessionFile(file, knownSkills);
 		total += recordNewInvocations(db, trackedSet, invocations);
+		progress?.update(done, files.length);
 	}
+	progress?.finish();
 
 	return total;
 }

--- a/packages/cli/src/scanner/connectors/cursor.ts
+++ b/packages/cli/src/scanner/connectors/cursor.ts
@@ -2,8 +2,10 @@ import type { Database } from "bun:sqlite";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
+import type { ProgressReporter } from "../../tui/progress";
 import type { Invocation } from "../index";
 import { recordNewInvocations } from "../index";
+import type { ScanCache } from "../scan-cache";
 
 export function parseCursorSessionFile(
 	filePath: string,
@@ -121,6 +123,8 @@ export async function scanCursorSessions(
 	db: Database,
 	trackedSet: Set<string>,
 	knownSkills: Set<string> = new Set(),
+	cache?: ScanCache,
+	progress?: ProgressReporter,
 ): Promise<number> {
 	let total = 0;
 
@@ -131,10 +135,18 @@ export async function scanCursorSessions(
 		for await (const file of glob.scan({ cwd: projectsDir, absolute: true })) {
 			files.push(file);
 		}
+		let done = 0;
 		for (const file of files) {
+			done++;
+			if (cache?.shouldSkip(file)) {
+				progress?.update(done, files.length);
+				continue;
+			}
 			const invocations = parseCursorSessionFile(file, knownSkills);
 			total += recordNewInvocations(db, trackedSet, invocations);
+			progress?.update(done, files.length);
 		}
+		progress?.finish();
 	}
 
 	return total;

--- a/packages/cli/src/scanner/connectors/gemini.ts
+++ b/packages/cli/src/scanner/connectors/gemini.ts
@@ -2,8 +2,10 @@ import type { Database } from "bun:sqlite";
 import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, join } from "node:path";
+import type { ProgressReporter } from "../../tui/progress";
 import type { Invocation } from "../index";
 import { recordNewInvocations } from "../index";
+import type { ScanCache } from "../scan-cache";
 
 interface GeminiMessage {
 	id?: string;
@@ -97,6 +99,8 @@ export async function scanGeminiSessions(
 	db: Database,
 	trackedSet: Set<string>,
 	knownSkills: Set<string> = new Set(),
+	cache?: ScanCache,
+	progress?: ProgressReporter,
 ): Promise<number> {
 	const tmpDir = join(homedir(), ".gemini", "tmp");
 	if (!existsSync(tmpDir)) return 0;
@@ -108,10 +112,18 @@ export async function scanGeminiSessions(
 	}
 
 	let total = 0;
+	let done = 0;
 	for (const file of files) {
+		done++;
+		if (cache?.shouldSkip(file)) {
+			progress?.update(done, files.length);
+			continue;
+		}
 		const invocations = parseGeminiSessionFile(file, knownSkills);
 		total += recordNewInvocations(db, trackedSet, invocations);
+		progress?.update(done, files.length);
 	}
+	progress?.finish();
 
 	return total;
 }

--- a/packages/cli/src/scanner/connectors/opencode.ts
+++ b/packages/cli/src/scanner/connectors/opencode.ts
@@ -5,6 +5,7 @@ import { homedir, platform } from "node:os";
 import { join } from "node:path";
 import type { Invocation } from "../index";
 import { recordNewInvocations } from "../index";
+import type { ScanCache } from "../scan-cache";
 
 function getDbPath(): string | null {
 	const os = platform();
@@ -76,7 +77,10 @@ export function countOpenCodeSessions(): number {
 export function scanOpenCodeSessions(
 	db: Database,
 	trackedSet: Set<string>,
+	cache?: ScanCache,
 ): number {
+	const dbPath = getDbPath();
+	if (dbPath && cache?.shouldSkip(dbPath)) return 0;
 	const ocDb = openDb();
 	if (!ocDb) return 0;
 

--- a/packages/cli/src/scanner/index.ts
+++ b/packages/cli/src/scanner/index.ts
@@ -1,5 +1,6 @@
 import type { Database } from "bun:sqlite";
 import { recordInvocation } from "../db/queries";
+import { createProgress } from "../tui/progress";
 import { countClaudeSessions, scanClaudeSessions } from "./connectors/claude";
 import { countCodexSessions, scanCodexSessions } from "./connectors/codex";
 import { countCursorSessions, scanCursorSessions } from "./connectors/cursor";
@@ -8,17 +9,48 @@ import {
 	countOpenCodeSessions,
 	scanOpenCodeSessions,
 } from "./connectors/opencode";
+import { ScanCache } from "./scan-cache";
 
 const BUILTIN_TOOL_NAMES = new Set([
-	"Read", "Write", "Edit", "MultiEdit", "Bash", "Glob", "Grep",
-	"WebSearch", "WebFetch", "TodoRead", "TodoWrite", "Task", "Agent",
-	"Skill", "LSP", "NotebookEdit", "AskFollowupQuestion",
-	"AttemptCompletion", "SearchReplace", "InsertCodeBlock",
-	"ReadImages", "ExecuteCommand", "ListFiles", "SearchFiles",
-	"ReadFile", "WriteFile", "ReplaceInFile", "ListCodeDefinitionNames",
-	"BrowserAction", "UseMcp", "shell", "shell_command",
-	"update_plan", "create_plan", "read_file", "write_file",
-	"execute_command", "spawn_agent", "write_stdin",
+	"Read",
+	"Write",
+	"Edit",
+	"MultiEdit",
+	"Bash",
+	"Glob",
+	"Grep",
+	"WebSearch",
+	"WebFetch",
+	"TodoRead",
+	"TodoWrite",
+	"Task",
+	"Agent",
+	"Skill",
+	"LSP",
+	"NotebookEdit",
+	"AskFollowupQuestion",
+	"AttemptCompletion",
+	"SearchReplace",
+	"InsertCodeBlock",
+	"ReadImages",
+	"ExecuteCommand",
+	"ListFiles",
+	"SearchFiles",
+	"ReadFile",
+	"WriteFile",
+	"ReplaceInFile",
+	"ListCodeDefinitionNames",
+	"BrowserAction",
+	"UseMcp",
+	"shell",
+	"shell_command",
+	"update_plan",
+	"create_plan",
+	"read_file",
+	"write_file",
+	"execute_command",
+	"spawn_agent",
+	"write_stdin",
 	"multi_tool_use.parallel",
 ]);
 
@@ -43,7 +75,9 @@ export function getTrackedSet(db: Database): Set<string> {
 			"SELECT skill_name, timestamp FROM skill_invocations",
 		)
 		.all();
-	return new Set(tracked.map((r) => `${r.skill_name}::${roundTs(r.timestamp)}`));
+	return new Set(
+		tracked.map((r) => `${r.skill_name}::${roundTs(r.timestamp)}`),
+	);
 }
 
 export interface Invocation {
@@ -63,7 +97,14 @@ export function recordNewInvocations(
 		if (!isSkillName(inv.skillName)) continue;
 		const key = `${inv.skillName}::${roundTs(inv.timestamp)}`;
 		if (!trackedSet.has(key)) {
-			recordInvocation(db, inv.skillName, inv.sessionId, undefined, inv.timestamp, inv.agent);
+			recordInvocation(
+				db,
+				inv.skillName,
+				inv.sessionId,
+				undefined,
+				inv.timestamp,
+				inv.agent,
+			);
 			trackedSet.add(key);
 			count++;
 		}
@@ -75,24 +116,53 @@ export async function scanAllSessions(
 	db: Database,
 	knownSkills: Set<string> = new Set(),
 	agentFilter?: string,
+	options: { force?: boolean; quiet?: boolean; cacheSalt?: string } = {},
 ): Promise<number> {
+	const { force = false, quiet = true, cacheSalt = "" } = options;
+	const cache = new ScanCache(db, { force, salt: cacheSalt });
+	const showProgress = !quiet && process.stdout.isTTY === true;
 	const trackedSet = getTrackedSet(db);
 	let total = 0;
 	if (!agentFilter || agentFilter === "claude") {
-		total += await scanClaudeSessions(db, trackedSet, knownSkills);
+		total += await scanClaudeSessions(
+			db,
+			trackedSet,
+			knownSkills,
+			cache,
+			createProgress("Claude Code sessions", showProgress),
+		);
 	}
 	if (!agentFilter || agentFilter === "opencode") {
-		total += scanOpenCodeSessions(db, trackedSet);
+		total += scanOpenCodeSessions(db, trackedSet, cache);
 	}
 	if (!agentFilter || agentFilter === "cursor") {
-		total += await scanCursorSessions(db, trackedSet, knownSkills);
+		total += await scanCursorSessions(
+			db,
+			trackedSet,
+			knownSkills,
+			cache,
+			createProgress("Cursor sessions", showProgress),
+		);
 	}
 	if (!agentFilter || agentFilter === "codex") {
-		total += await scanCodexSessions(db, trackedSet, knownSkills);
+		total += await scanCodexSessions(
+			db,
+			trackedSet,
+			knownSkills,
+			cache,
+			createProgress("Codex sessions", showProgress),
+		);
 	}
 	if (!agentFilter || agentFilter === "gemini") {
-		total += await scanGeminiSessions(db, trackedSet, knownSkills);
+		total += await scanGeminiSessions(
+			db,
+			trackedSet,
+			knownSkills,
+			cache,
+			createProgress("Gemini CLI sessions", showProgress),
+		);
 	}
+	cache.flush();
 	return total;
 }
 

--- a/packages/cli/src/scanner/scan-cache.ts
+++ b/packages/cli/src/scanner/scan-cache.ts
@@ -1,0 +1,70 @@
+import type { Database } from "bun:sqlite";
+import { statSync } from "node:fs";
+
+export class ScanCache {
+	private known = new Map<string, string>();
+	private pending: Array<[string, string]> = [];
+	private force: boolean;
+
+	constructor(
+		private db: Database,
+		options: { force?: boolean; salt?: string } = {},
+	) {
+		this.force = options.force ?? false;
+		db.run(
+			"CREATE TABLE IF NOT EXISTS scanned_files (path TEXT PRIMARY KEY, fingerprint TEXT NOT NULL)",
+		);
+		db.run(
+			"CREATE TABLE IF NOT EXISTS scan_meta (key TEXT PRIMARY KEY, value TEXT NOT NULL)",
+		);
+
+		const salt = options.salt ?? "";
+		const stored = db
+			.query<{ value: string }, [string]>(
+				"SELECT value FROM scan_meta WHERE key = ?",
+			)
+			.get("skills_salt");
+
+		if (stored?.value !== salt) {
+			db.run("DELETE FROM scanned_files");
+			db.run(
+				"INSERT INTO scan_meta (key, value) VALUES ('skills_salt', ?) ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+				[salt],
+			);
+		} else if (!this.force) {
+			const rows = this.db
+				.query<{ path: string; fingerprint: string }, []>(
+					"SELECT path, fingerprint FROM scanned_files",
+				)
+				.all();
+			for (const row of rows) {
+				this.known.set(row.path, row.fingerprint);
+			}
+		}
+	}
+
+	shouldSkip(path: string): boolean {
+		let fingerprint: string;
+		try {
+			const st = statSync(path);
+			fingerprint = `${Math.floor(st.mtimeMs)}:${st.size}`;
+		} catch {
+			return false;
+		}
+		if (!this.force && this.known.get(path) === fingerprint) return true;
+		this.pending.push([path, fingerprint]);
+		return false;
+	}
+
+	flush(): void {
+		if (this.pending.length === 0) return;
+		const insert = this.db.prepare(
+			"INSERT INTO scanned_files (path, fingerprint) VALUES (?, ?) ON CONFLICT(path) DO UPDATE SET fingerprint = excluded.fingerprint",
+		);
+		const tx = this.db.transaction((rows: Array<[string, string]>) => {
+			for (const row of rows) insert.run(row[0], row[1]);
+		});
+		tx(this.pending);
+		this.pending = [];
+	}
+}

--- a/packages/cli/src/tui/progress.ts
+++ b/packages/cli/src/tui/progress.ts
@@ -1,0 +1,29 @@
+import { dim } from "./colors";
+
+export interface ProgressReporter {
+	update(done: number, total: number): void;
+	finish(): void;
+}
+
+export function createProgress(
+	label: string,
+	enabled: boolean,
+): ProgressReporter {
+	let lastRender = 0;
+	let rendered = false;
+	return {
+		update(done: number, total: number): void {
+			if (!enabled || total === 0) return;
+			const now = Date.now();
+			if (now - lastRender < 40 && done < total) return;
+			lastRender = now;
+			rendered = true;
+			process.stdout.write(
+				`\r\x1b[2K  ${dim(`Indexing ${label}`)} ${done}/${total}`,
+			);
+		},
+		finish(): void {
+			if (enabled && rendered) process.stdout.write("\r\x1b[2K");
+		},
+	};
+}


### PR DESCRIPTION
## Problem

Every `skillkit scan` re-parsed all session files (5,260 on a mature machine) even when nothing changed, with zero feedback while running. `skillkit stats` triggered the same silent full scan. ~15s wall-clock per invocation, twice if you ran scan + stats back to back.

## What

**Incremental cache.** New `scanned_files` table keyed by absolute path with an `mtime:size` fingerprint. Connectors skip unchanged files entirely; only new or modified sessions get parsed. The invocation dedupe (trackedSet) is unchanged, so re-parsing a touched file never double-counts.

**Automatic invalidation.** The cache carries a salt derived from the sorted installed-skill names (`scan_meta`). Install or remove a skill and the next scan re-indexes everything so the new skill's historical invocations are picked up. The salt intentionally excludes commands so alternating `scan` / `stats` (which differ on `includeCommands`) does not ping-pong the cache.

**`scan --full`** bypasses and rebuilds the cache (documented in help).

**Feedback.** TTY progress counter per agent (`Indexing Claude Code sessions 44/2313`, in-place updates, cleared when done) — hidden under `--quiet`, `--json`, and non-TTY (so the SessionEnd hook stays silent). Scan summary now appends elapsed time.

**OpenCode** fingerprints its sqlite db file with the same mechanism.

## Measured (real machine, 5,263 sessions)

```
cold scan (builds cache):  15.4s
warm scan:                  0.17s   (~90x)
stats right after scan:     0.10s
touch one session file:     0.13s  (re-parses only that file, no dupes)
```

## Tests

- 5 new ScanCache unit tests: skip-when-fresh, rescan on content change, rescan on mtime-only change, salt invalidation, force rebuild.
- Full suite: same 7 pre-existing failures as main, nothing new.
- Progress rendering verified under a real TTY via `script`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SBRGWen5utt7WBNtBKdMtU