### PR TITLE
feat(context): measure MCP tool schemas and track context drift

### DIFF
--- a/packages/cli/src/__tests__/baseline.test.ts
+++ b/packages/cli/src/__tests__/baseline.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "bun:test";
+import {
+	type BaselineSnapshot,
+	type BaselineSource,
+	diffBaseline,
+	formatRelativeAge,
+} from "../context/baseline";
+
+function snapshot(
+	sources: BaselineSource[],
+	createdAt = "2026-07-01T00:00:00.000Z",
+): BaselineSnapshot {
+	return {
+		name: "test",
+		createdAt,
+		cwd: "/tmp/project",
+		totalTokens: sources.reduce((s, x) => s + x.tokens, 0),
+		sources,
+	};
+}
+
+describe("diffBaseline", () => {
+	it("reports no changes when nothing moved", () => {
+		const sources: BaselineSource[] = [
+			{ name: "./CLAUDE.md", type: "claude-md", tokens: 6500 },
+			{ name: "skill-a", type: "skill-metadata", tokens: 200 },
+		];
+		const diff = diffBaseline(snapshot(sources), sources);
+
+		expect(diff.changes).toHaveLength(0);
+		expect(diff.totalDelta).toBe(0);
+		expect(diff.pctDelta).toBe(0);
+	});
+
+	it("detects an added source", () => {
+		const before: BaselineSource[] = [
+			{ name: "./CLAUDE.md", type: "claude-md", tokens: 6500 },
+		];
+		const after: BaselineSource[] = [
+			...before,
+			{ name: "firecrawl", type: "mcp", tokens: 3200 },
+		];
+		const diff = diffBaseline(snapshot(before), after);
+
+		expect(diff.changes).toHaveLength(1);
+		expect(diff.changes[0]).toMatchObject({
+			name: "firecrawl",
+			kind: "added",
+			before: 0,
+			after: 3200,
+			delta: 3200,
+		});
+		expect(diff.totalDelta).toBe(3200);
+	});
+
+	it("detects a removed source", () => {
+		const before: BaselineSource[] = [
+			{ name: "./CLAUDE.md", type: "claude-md", tokens: 6500 },
+			{ name: "dead-skill", type: "skill-metadata", tokens: 412 },
+		];
+		const after: BaselineSource[] = [
+			{ name: "./CLAUDE.md", type: "claude-md", tokens: 6500 },
+		];
+		const diff = diffBaseline(snapshot(before), after);
+
+		expect(diff.changes).toHaveLength(1);
+		expect(diff.changes[0]).toMatchObject({
+			name: "dead-skill",
+			kind: "removed",
+			after: 0,
+			delta: -412,
+		});
+		expect(diff.totalDelta).toBe(-412);
+	});
+
+	it("detects a changed source", () => {
+		const before: BaselineSource[] = [
+			{ name: "./CLAUDE.md", type: "claude-md", tokens: 6500 },
+		];
+		const after: BaselineSource[] = [
+			{ name: "./CLAUDE.md", type: "claude-md", tokens: 6691 },
+		];
+		const diff = diffBaseline(snapshot(before), after);
+
+		expect(diff.changes[0]).toMatchObject({
+			kind: "changed",
+			before: 6500,
+			after: 6691,
+			delta: 191,
+		});
+	});
+
+	it("keys by type so a file and a skill sharing a name never collide", () => {
+		const before: BaselineSource[] = [
+			{ name: "research", type: "claude-md", tokens: 100 },
+		];
+		const after: BaselineSource[] = [
+			{ name: "research", type: "claude-md", tokens: 100 },
+			{ name: "research", type: "skill-metadata", tokens: 250 },
+		];
+		const diff = diffBaseline(snapshot(before), after);
+
+		expect(diff.changes).toHaveLength(1);
+		expect(diff.changes[0]).toMatchObject({
+			kind: "added",
+			type: "skill-metadata",
+			delta: 250,
+		});
+	});
+
+	it("sorts changes by magnitude, largest first", () => {
+		const before: BaselineSource[] = [
+			{ name: "small", type: "skill-metadata", tokens: 100 },
+			{ name: "big", type: "skill-metadata", tokens: 100 },
+		];
+		const after: BaselineSource[] = [
+			{ name: "small", type: "skill-metadata", tokens: 150 },
+			{ name: "big", type: "skill-metadata", tokens: 5000 },
+		];
+		const diff = diffBaseline(snapshot(before), after);
+
+		expect(diff.changes.map((c) => c.name)).toEqual(["big", "small"]);
+	});
+
+	it("computes percent delta against the baseline total", () => {
+		const before: BaselineSource[] = [
+			{ name: "a", type: "claude-md", tokens: 1000 },
+		];
+		const after: BaselineSource[] = [
+			{ name: "a", type: "claude-md", tokens: 1290 },
+		];
+		const diff = diffBaseline(snapshot(before), after);
+
+		expect(diff.pctDelta).toBeCloseTo(29, 5);
+	});
+
+	it("does not divide by zero on an empty baseline", () => {
+		const diff = diffBaseline(snapshot([]), [
+			{ name: "a", type: "claude-md", tokens: 500 },
+		]);
+
+		expect(diff.pctDelta).toBe(0);
+		expect(diff.totalDelta).toBe(500);
+	});
+});
+
+describe("formatRelativeAge", () => {
+	const now = new Date("2026-07-25T12:00:00.000Z");
+
+	it("formats minutes, hours and days", () => {
+		expect(formatRelativeAge("2026-07-25T11:59:40.000Z", now)).toBe("just now");
+		expect(formatRelativeAge("2026-07-25T11:30:00.000Z", now)).toBe("30m ago");
+		expect(formatRelativeAge("2026-07-25T09:00:00.000Z", now)).toBe("3h ago");
+		expect(formatRelativeAge("2026-07-19T12:00:00.000Z", now)).toBe("6d ago");
+	});
+
+	it("handles an unparseable timestamp", () => {
+		expect(formatRelativeAge("not-a-date", now)).toBe("unknown");
+	});
+});

--- a/packages/cli/src/__tests__/context-imports.test.ts
+++ b/packages/cli/src/__tests__/context-imports.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it } from "bun:test";
+import { mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { findContextFiles } from "../commands/context";
+
+function project(files: Record<string, string>): string {
+	const dir = mkdtempSync(join(tmpdir(), "skillkit-ctx-"));
+	for (const [rel, content] of Object.entries(files)) {
+		const full = join(dir, rel);
+		mkdirSync(join(full, ".."), { recursive: true });
+		writeFileSync(full, content);
+	}
+	return dir;
+}
+
+/** Only sources produced from this temp dir; the walk also sees ~/.claude. */
+function localSources(dir: string) {
+	return findContextFiles(dir).filter((s) => s.path.startsWith(dir));
+}
+
+describe("findContextFiles", () => {
+	it("resolves a direct @import", () => {
+		const dir = project({
+			"CLAUDE.md": "@docs/a.md\n",
+			"docs/a.md": "alpha",
+		});
+		const names = localSources(dir).map((s) => s.name);
+
+		expect(names).toEqual(["a.md"]);
+	});
+
+	// An imported file may import more; the model pays for the whole closure.
+	it("follows imports transitively", () => {
+		const dir = project({
+			"CLAUDE.md": "@a.md\n",
+			"a.md": "@b.md\n",
+			"b.md": "@c.md\n",
+			"c.md": "leaf",
+		});
+		const names = localSources(dir)
+			.map((s) => s.name)
+			.sort();
+
+		expect(names).toEqual(["a.md", "b.md", "c.md"]);
+	});
+
+	// Counting a shared file once per referrer inflated the reported tax.
+	it("counts a file referenced twice only once", () => {
+		const dir = project({
+			"CLAUDE.md": "@a.md\n@b.md\n",
+			"a.md": "@shared.md\n",
+			"b.md": "@shared.md\n",
+			"shared.md": "x".repeat(500),
+		});
+		const shared = localSources(dir).filter((s) => s.name === "shared.md");
+
+		expect(shared).toHaveLength(1);
+	});
+
+	it("terminates on an import cycle", () => {
+		const dir = project({
+			"CLAUDE.md": "@a.md\n",
+			"a.md": "@b.md\n",
+			"b.md": "@a.md\n",
+		});
+
+		const names = localSources(dir)
+			.map((s) => s.name)
+			.sort();
+		expect(names).toEqual(["a.md", "b.md"]);
+	});
+
+	it("ignores an import whose target does not exist", () => {
+		const dir = project({ "CLAUDE.md": "@missing.md\n" });
+
+		expect(localSources(dir)).toHaveLength(0);
+	});
+
+	it("records the byte length of each imported file", () => {
+		const dir = project({
+			"CLAUDE.md": "@a.md\n",
+			"a.md": "y".repeat(370),
+		});
+		const source = localSources(dir).find((s) => s.name === "a.md");
+
+		expect(source?.chars).toBe(370);
+		expect(source?.tokens).toBe(100);
+	});
+});

--- a/packages/cli/src/__tests__/mcp.test.ts
+++ b/packages/cli/src/__tests__/mcp.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	discoverMcpServers,
+	type McpServerConfig,
+	measureMcpServer,
+	pickFailureReason,
+} from "../scanner/mcp";
+
+function tempProject(mcpJson?: unknown): string {
+	const dir = mkdtempSync(join(tmpdir(), "skillkit-mcp-"));
+	if (mcpJson !== undefined) {
+		writeFileSync(join(dir, ".mcp.json"), JSON.stringify(mcpJson));
+	}
+	return dir;
+}
+
+describe("discoverMcpServers", () => {
+	it("returns an empty list for a directory with no config", () => {
+		const dir = tempProject();
+		const servers = discoverMcpServers(dir);
+		const fromRepo = servers.filter((s) => s.scope === "mcp-json");
+
+		expect(fromRepo).toHaveLength(0);
+	});
+
+	it("reads servers from a repo-level .mcp.json", () => {
+		const dir = tempProject({
+			mcpServers: {
+				local: { command: "bun", args: ["run", "server.ts"] },
+			},
+		});
+		const server = discoverMcpServers(dir).find((s) => s.name === "local");
+
+		expect(server).toBeDefined();
+		expect(server?.scope).toBe("mcp-json");
+		expect(server?.transport).toBe("stdio");
+		expect(server?.command).toBe("bun");
+		expect(server?.args).toEqual(["run", "server.ts"]);
+	});
+
+	it("infers stdio from a command and http from a url", () => {
+		const dir = tempProject({
+			mcpServers: {
+				viaCommand: { command: "npx", args: ["-y", "some-server"] },
+				viaUrl: { url: "https://example.com/mcp" },
+			},
+		});
+		const servers = discoverMcpServers(dir);
+
+		expect(servers.find((s) => s.name === "viaCommand")?.transport).toBe(
+			"stdio",
+		);
+		expect(servers.find((s) => s.name === "viaUrl")?.transport).toBe("http");
+	});
+
+	it("honours an explicit type field over inference", () => {
+		const dir = tempProject({
+			mcpServers: {
+				explicit: { type: "sse", url: "https://example.com/sse" },
+			},
+		});
+
+		expect(
+			discoverMcpServers(dir).find((s) => s.name === "explicit")?.transport,
+		).toBe("sse");
+	});
+
+	it("marks a server with neither command nor url as unknown transport", () => {
+		const dir = tempProject({ mcpServers: { broken: {} } });
+
+		expect(
+			discoverMcpServers(dir).find((s) => s.name === "broken")?.transport,
+		).toBe("unknown");
+	});
+
+	it("survives malformed JSON without throwing", () => {
+		const dir = mkdtempSync(join(tmpdir(), "skillkit-mcp-bad-"));
+		writeFileSync(join(dir, ".mcp.json"), "{ not valid json");
+
+		expect(() => discoverMcpServers(dir)).not.toThrow();
+		expect(
+			discoverMcpServers(dir).filter((s) => s.scope === "mcp-json"),
+		).toHaveLength(0);
+	});
+
+	it("dedupes server names case-insensitively", () => {
+		const dir = tempProject({
+			mcpServers: {
+				alphaXiv: { command: "a" },
+				alphaxiv: { command: "b" },
+			},
+		});
+		const matches = discoverMcpServers(dir).filter(
+			(s) => s.name.toLowerCase() === "alphaxiv",
+		);
+
+		expect(matches).toHaveLength(1);
+	});
+
+	it("returns servers sorted by name", () => {
+		const dir = tempProject({
+			mcpServers: {
+				zebra: { command: "a" },
+				alpha: { command: "b" },
+				middle: { command: "c" },
+			},
+		});
+		const names = discoverMcpServers(dir)
+			.filter((s) => s.scope === "mcp-json")
+			.map((s) => s.name);
+
+		expect(names).toEqual([...names].sort());
+	});
+});
+
+describe("pickFailureReason", () => {
+	it("prefers an error line over a trailing version banner", () => {
+		const stderr = [
+			"Error: Cannot find module 'excalidraw-mcp'",
+			"Node.js v24.16.0",
+		].join("\n");
+
+		expect(pickFailureReason(stderr, 1)).toBe(
+			"Error: Cannot find module 'excalidraw-mcp'",
+		);
+	});
+
+	it("falls back to the exit code when stderr has no error line", () => {
+		expect(pickFailureReason("Listening on stdio\n", 3)).toBe(
+			"exited with code 3",
+		);
+	});
+
+	it("reports an empty stderr without inventing a cause", () => {
+		expect(pickFailureReason("", null)).toBe("server exited without output");
+	});
+
+	it("truncates a very long error line", () => {
+		const reason = pickFailureReason(`Error: ${"x".repeat(500)}`, 1);
+
+		expect(reason.length).toBeLessThanOrEqual(160);
+		expect(reason.endsWith("...")).toBe(true);
+	});
+});
+
+describe("measureMcpServer", () => {
+	it("reports http transport as unsupported rather than zero", async () => {
+		const config: McpServerConfig = {
+			name: "remote",
+			scope: "user",
+			transport: "http",
+			url: "https://example.com/mcp",
+		};
+		const result = await measureMcpServer(config);
+
+		expect(result.status).toBe("unsupported");
+		expect(result.chars).toBe(0);
+		expect(result.reason).toContain("http");
+	});
+
+	it("reports a server that cannot start as failed, not measured", async () => {
+		const config: McpServerConfig = {
+			name: "ghost",
+			scope: "user",
+			transport: "stdio",
+			command: "skillkit-nonexistent-binary-xyz",
+			args: [],
+		};
+		const result = await measureMcpServer(config, 5_000);
+
+		expect(result.status).toBe("failed");
+		expect(result.toolCount).toBe(0);
+		expect(result.reason).toBeTruthy();
+	});
+
+	it("times out a server that never answers", async () => {
+		const config: McpServerConfig = {
+			name: "silent",
+			scope: "user",
+			transport: "stdio",
+			command: "sleep",
+			args: ["30"],
+		};
+		const result = await measureMcpServer(config, 1_000);
+
+		expect(result.status).toBe("timeout");
+		expect(result.chars).toBe(0);
+	});
+
+	// A pipe that echoes stdin replays our own requests. Without a response
+	// guard the echoed tools/list reads as a successful reply with zero tools,
+	// silently reporting a broken server as free.
+	it("does not treat an echoed request as a valid response", async () => {
+		const config: McpServerConfig = {
+			name: "echo",
+			scope: "user",
+			transport: "stdio",
+			command: "cat",
+			args: [],
+		};
+		const result = await measureMcpServer(config, 1_500);
+
+		expect(result.status).not.toBe("ok");
+		expect(result.chars).toBe(0);
+	});
+});

--- a/packages/cli/src/__tests__/pricing.test.ts
+++ b/packages/cli/src/__tests__/pricing.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "bun:test";
+import { getPricing } from "../commands/burn";
+
+describe("getPricing", () => {
+	it("keeps published cache pricing for Anthropic models", () => {
+		const pricing = getPricing("claude-opus-4");
+
+		expect(pricing.input).toBe(15);
+		expect(pricing.cacheCreate).toBe(18.75);
+		expect(pricing.cacheRead).toBe(1.5);
+	});
+
+	// Most entries in MODEL_PRICING declare no cache pricing. Reading those
+	// fields raw gave undefined, and tokens * undefined is NaN, which then
+	// spread through every total it was added to and voided the cost report.
+	it("derives cache pricing for models that declare none", () => {
+		const pricing = getPricing("gpt-5.4");
+
+		expect(pricing.cacheCreate).toBeDefined();
+		expect(pricing.cacheRead).toBeDefined();
+		expect(Number.isFinite(pricing.cacheCreate)).toBe(true);
+		expect(Number.isFinite(pricing.cacheRead)).toBe(true);
+	});
+
+	it("never yields NaN when costing a session with cache tokens", () => {
+		for (const model of [
+			"gpt-5.4",
+			"gpt-5",
+			"claude-opus-4",
+			"totally-unknown-model",
+		]) {
+			const p = getPricing(model);
+			const cost =
+				(100 * p.input +
+					50 * p.output +
+					1000 * p.cacheCreate +
+					5000 * p.cacheRead) /
+				1_000_000;
+
+			expect(Number.isNaN(cost)).toBe(false);
+			expect(cost).toBeGreaterThan(0);
+		}
+	});
+
+	it("prices a cache read below a cache write", () => {
+		const pricing = getPricing("gpt-5.4");
+
+		expect(pricing.cacheRead).toBeLessThan(pricing.cacheCreate);
+	});
+
+	it("falls back to mid-tier pricing for an unknown model", () => {
+		const pricing = getPricing("some-model-that-does-not-exist");
+
+		expect(pricing.input).toBe(2);
+		expect(pricing.output).toBe(10);
+		expect(Number.isFinite(pricing.cacheRead)).toBe(true);
+	});
+});

--- a/packages/cli/src/bin.ts
+++ b/packages/cli/src/bin.ts
@@ -48,8 +48,13 @@ function printHelp(): void {
     ${dim("burn")} ${cyan("--days N")}             Time range in days (default: 30)
     ${dim("burn")} ${cyan("--plan N")}             Monthly plan cost in USD (default: 200)
     ${dim("burn")} ${cyan("--json")}               JSON output
-    ${dim("context")} ${cyan("--opus/--haiku")}      Model pricing (default: sonnet)
+    ${dim("context")} ${cyan("--sonnet/--haiku")}    Model pricing (default: opus)
     ${dim("context")} ${cyan("--turns N")}          Avg turns per session (default: 40)
+    ${dim("context")} ${cyan("--mcp")}              Measure MCP server tool schemas
+    ${dim("context")} ${cyan("--mcp-timeout N")}    Per-server probe timeout in s (default: 20)
+    ${dim("context")} ${cyan("--save-baseline <n>")} Save current measurement as baseline
+    ${dim("context")} ${cyan("--compare <n>")}      Diff against a saved baseline
+    ${dim("context")} ${cyan("--list-baselines")}   List saved baselines
     ${dim("context")} ${cyan("--json")}             JSON output
     ${dim("any")}   ${cyan("--claude")}             Only scan Claude Code
     ${dim("any")}   ${cyan("--cursor")}             Only scan Cursor

--- a/packages/cli/src/commands/burn.ts
+++ b/packages/cli/src/commands/burn.ts
@@ -168,14 +168,43 @@ const unmappedModelsWarned = new Set<string>();
 
 const INTERNAL_MODELS = /^<.*>$|^synthetic$|^test$|^unknown$/i;
 
-function getPricing(model: string): ModelPricing {
+/**
+ * Standard cache multipliers, used when a model has no published cache
+ * pricing of its own: a cache write costs 1.25x input, a cache read 0.1x.
+ *
+ * Most entries in MODEL_PRICING (every non-Anthropic one) omit cacheCreate
+ * and cacheRead. Reading those straight off the record yields `undefined`,
+ * and `tokens * undefined` is NaN, which then propagates through every
+ * running total it touches and silently voids the whole cost report.
+ */
+const CACHE_WRITE_MULTIPLIER = 1.25;
+const CACHE_READ_MULTIPLIER = 0.1;
+
+/** Pricing with every cost field guaranteed present. */
+type ResolvedPricing = Required<
+	Pick<ModelPricing, "input" | "output" | "cacheCreate" | "cacheRead">
+> &
+	Pick<ModelPricing, "avgIn" | "avgOut">;
+
+function resolvePricing(pricing: ModelPricing): ResolvedPricing {
+	return {
+		input: pricing.input,
+		output: pricing.output,
+		cacheCreate: pricing.cacheCreate ?? pricing.input * CACHE_WRITE_MULTIPLIER,
+		cacheRead: pricing.cacheRead ?? pricing.input * CACHE_READ_MULTIPLIER,
+		avgIn: pricing.avgIn,
+		avgOut: pricing.avgOut,
+	};
+}
+
+export function getPricing(model: string): ResolvedPricing {
 	for (const [key, pricing] of Object.entries(MODEL_PRICING)) {
-		if (model.includes(key)) return pricing;
+		if (model.includes(key)) return resolvePricing(pricing);
 	}
 	if (!INTERNAL_MODELS.test(model) && !unmappedModelsWarned.has(model)) {
 		unmappedModelsWarned.add(model);
 	}
-	return FALLBACK_PRICING;
+	return resolvePricing(FALLBACK_PRICING);
 }
 
 

--- a/packages/cli/src/commands/context.ts
+++ b/packages/cli/src/commands/context.ts
@@ -1,6 +1,6 @@
-import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { existsSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, dirname, join } from "node:path";
+import { dirname, join } from "node:path";
 import {
 	type BaselineSource,
 	deleteBaseline,
@@ -128,30 +128,62 @@ function findClaudeMdFiles(cwd: string): ContextSource[] {
 	return sources;
 }
 
-function findContextFiles(cwd: string): ContextSource[] {
+const MAX_IMPORT_DEPTH = 5;
+
+/**
+ * Resolve `@path/to/file.md` imports reachable from the CLAUDE.md files.
+ *
+ * Two properties matter for the token total to be right:
+ *  - each file is counted once, even when several CLAUDE.md files (or a
+ *    chain of imports) reference it, so shared context is not double-billed
+ *  - imports are followed transitively, since an imported file may itself
+ *    import more, and the model pays for the whole closure
+ *
+ * Depth is capped and visited paths are tracked, so an import cycle
+ * terminates instead of recursing forever.
+ */
+export function findContextFiles(cwd: string): ContextSource[] {
 	const sources: ContextSource[] = [];
+	const visited = new Set<string>();
 
 	const claudeMdFiles = findClaudeMdFiles(cwd);
-	for (const claudeMd of claudeMdFiles) {
-		const content = readFileSync(claudeMd.path, "utf-8");
+	for (const claudeMd of claudeMdFiles) visited.add(claudeMd.path);
+
+	const walk = (filePath: string, depth: number): void => {
+		if (depth > MAX_IMPORT_DEPTH) return;
+
+		let content: string;
+		try {
+			content = readFileSync(filePath, "utf-8");
+		} catch {
+			return;
+		}
+
 		const atRefs = content.match(/^@(.+\.md)$/gm);
-		if (!atRefs) continue;
+		if (!atRefs) return;
 
 		for (const ref of atRefs) {
-			const refPath = ref.slice(1);
-			const fullPath = join(dirname(claudeMd.path), refPath);
-			if (existsSync(fullPath)) {
-				const refContent = readFileSync(fullPath, "utf-8");
-				sources.push({
-					name: refPath.replace(/.*\//, ""),
-					path: fullPath,
-					chars: refContent.length,
-					tokens: charsToTokens(refContent.length),
-					type: "claude-md",
-				});
-			}
+			const refPath = ref.slice(1).trim();
+			const fullPath = join(dirname(filePath), refPath);
+			if (visited.has(fullPath)) continue;
+			visited.add(fullPath);
+
+			if (!existsSync(fullPath)) continue;
+
+			const refContent = readFileSync(fullPath, "utf-8");
+			sources.push({
+				name: refPath.replace(/.*\//, ""),
+				path: fullPath,
+				chars: refContent.length,
+				tokens: charsToTokens(refContent.length),
+				type: "claude-md",
+			});
+
+			walk(fullPath, depth + 1);
 		}
-	}
+	};
+
+	for (const claudeMd of claudeMdFiles) walk(claudeMd.path, 0);
 
 	return sources;
 }

--- a/packages/cli/src/commands/context.ts
+++ b/packages/cli/src/commands/context.ts
@@ -1,15 +1,32 @@
 import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import { basename, dirname, join } from "node:path";
+import {
+	type BaselineSource,
+	deleteBaseline,
+	diffBaseline,
+	formatRelativeAge,
+	listBaselines,
+	loadBaseline,
+	saveBaseline,
+} from "../context/baseline";
+import {
+	discoverMcpServers,
+	type McpServerMeasurement,
+	measureMcpServers,
+} from "../scanner/mcp";
 import { scanInstalledSkills } from "../scanner/skills";
 import { bold, cyan, dim, green, red, yellow } from "../tui/colors";
 
 const CHARS_PER_TOKEN = 3.7;
 
-const MODEL_PRICING: Record<string, { input: number; cacheWrite: number; cacheRead: number }> = {
-	"opus": { input: 15, cacheWrite: 18.75, cacheRead: 1.5 },
-	"sonnet": { input: 3, cacheWrite: 3.75, cacheRead: 0.30 },
-	"haiku": { input: 0.80, cacheWrite: 1, cacheRead: 0.08 },
+const MODEL_PRICING: Record<
+	string,
+	{ input: number; cacheWrite: number; cacheRead: number }
+> = {
+	opus: { input: 15, cacheWrite: 18.75, cacheRead: 1.5 },
+	sonnet: { input: 3, cacheWrite: 3.75, cacheRead: 0.3 },
+	haiku: { input: 0.8, cacheWrite: 1, cacheRead: 0.08 },
 };
 
 function charsToTokens(chars: number): number {
@@ -37,7 +54,19 @@ interface ContextSource {
 	path: string;
 	chars: number;
 	tokens: number;
-	type: "claude-md" | "memory" | "skill-metadata" | "skill-body";
+	type: "claude-md" | "memory" | "skill-metadata" | "skill-body" | "mcp";
+}
+
+function mcpToSources(measurements: McpServerMeasurement[]): ContextSource[] {
+	return measurements
+		.filter((m) => m.status === "ok")
+		.map((m) => ({
+			name: m.name,
+			path: `mcp:${m.name}`,
+			chars: m.chars,
+			tokens: charsToTokens(m.chars),
+			type: "mcp" as const,
+		}));
 }
 
 function findClaudeMdFiles(cwd: string): ContextSource[] {
@@ -59,10 +88,15 @@ function findClaudeMdFiles(cwd: string): ContextSource[] {
 	const seen = new Set<string>();
 	while (true) {
 		const candidate = join(dir, "CLAUDE.md");
-		if (existsSync(candidate) && !seen.has(candidate) && candidate !== globalPath) {
+		if (
+			existsSync(candidate) &&
+			!seen.has(candidate) &&
+			candidate !== globalPath
+		) {
 			seen.add(candidate);
 			const content = readFileSync(candidate, "utf-8");
-			const rel = dir === cwd ? "./CLAUDE.md" : candidate.replace(homedir(), "~");
+			const rel =
+				dir === cwd ? "./CLAUDE.md" : candidate.replace(homedir(), "~");
 			sources.push({
 				name: rel,
 				path: candidate,
@@ -152,7 +186,10 @@ function findMemoryFiles(): ContextSource[] {
 	return sources;
 }
 
-function getSkillSources(): { metadata: ContextSource[]; bodies: ContextSource[] } {
+function getSkillSources(): {
+	metadata: ContextSource[];
+	bodies: ContextSource[];
+} {
 	const skills = scanInstalledSkills();
 	const metadata: ContextSource[] = [];
 	const bodies: ContextSource[] = [];
@@ -171,9 +208,11 @@ function getSkillSources(): { metadata: ContextSource[]; bodies: ContextSource[]
 			if (fmMatch) {
 				const yaml = fmMatch[1] ?? "";
 				const nameMatch = yaml.match(/^name:\s*(.+)$/m);
-				if (nameMatch?.[1]) name = nameMatch[1].trim().replace(/^["']|["']$/g, "");
+				if (nameMatch?.[1])
+					name = nameMatch[1].trim().replace(/^["']|["']$/g, "");
 				const descMatch = yaml.match(/^description:\s*(.+)$/m);
-				if (descMatch?.[1]) description = descMatch[1].trim().replace(/^["']|["']$/g, "");
+				if (descMatch?.[1])
+					description = descMatch[1].trim().replace(/^["']|["']$/g, "");
 			}
 
 			const metaChars = name.length + description.length;
@@ -199,36 +238,136 @@ function getSkillSources(): { metadata: ContextSource[]; bodies: ContextSource[]
 	return { metadata, bodies };
 }
 
+function flagValue(args: string[], flag: string): string | undefined {
+	const idx = args.indexOf(flag);
+	if (idx < 0) return undefined;
+	const next = args[idx + 1];
+	if (!next || next.startsWith("--")) return undefined;
+	return next;
+}
+
 export async function runContextCommand(): Promise<void> {
 	const args = process.argv.slice(3);
 	const isJson = args.includes("--json");
-	const model = args.includes("--sonnet") ? "sonnet" : args.includes("--haiku") ? "haiku" : "opus";
+	const model = args.includes("--sonnet")
+		? "sonnet"
+		: args.includes("--haiku")
+			? "haiku"
+			: "opus";
 	const turnsFlag = args.indexOf("--turns");
-	const avgTurns = turnsFlag >= 0 && args[turnsFlag + 1] ? Number(args[turnsFlag + 1]) : 40;
+	const avgTurns =
+		turnsFlag >= 0 && args[turnsFlag + 1] ? Number(args[turnsFlag + 1]) : 40;
+	const withMcp = args.includes("--mcp");
+	const mcpTimeout = Number(flagValue(args, "--mcp-timeout") ?? 20) * 1000;
 
 	const pricing = MODEL_PRICING[model]!;
 	const cwd = process.cwd();
+
+	if (args.includes("--list-baselines")) {
+		const all = listBaselines(cwd);
+		if (all.length === 0) {
+			console.log("");
+			console.log(`  ${dim("No baselines saved for this directory.")}`);
+			console.log(
+				`  ${dim("Create one with:")} skillkit context --save-baseline <name>`,
+			);
+			console.log("");
+			return;
+		}
+		console.log("");
+		console.log(`  ${bold("CONTEXT BASELINES")} ${dim(`(${cwd})`)}`);
+		console.log("");
+		for (const b of all) {
+			console.log(
+				`    ${b.name.padEnd(24)} ${formatTokens(b.totalTokens).padStart(8)} tokens   ${dim(formatRelativeAge(b.createdAt))}`,
+			);
+		}
+		console.log("");
+		return;
+	}
+
+	const toDelete = flagValue(args, "--delete-baseline");
+	if (toDelete) {
+		const existed = deleteBaseline(toDelete, cwd);
+		console.log("");
+		console.log(
+			existed
+				? `  ${green("✓")} Deleted baseline "${toDelete}"`
+				: `  ${red("✗")} No baseline named "${toDelete}"`,
+		);
+		console.log("");
+		return;
+	}
+
+	const saveName = args.includes("--save-baseline")
+		? (flagValue(args, "--save-baseline") ?? "default")
+		: undefined;
+	const compareName = args.includes("--compare")
+		? (flagValue(args, "--compare") ?? "default")
+		: undefined;
 
 	const claudeMdSources = findClaudeMdFiles(cwd);
 	const contextFileSources = findContextFiles(cwd);
 	const memorySources = findMemoryFiles();
 	const { metadata: skillMetadata, bodies: skillBodies } = getSkillSources();
 
+	let mcpMeasurements: McpServerMeasurement[] = [];
+	let mcpSources: ContextSource[] = [];
+	if (withMcp) {
+		const servers = discoverMcpServers(cwd);
+		if (servers.length > 0) {
+			if (!isJson) {
+				process.stderr.write(
+					dim(
+						`  Probing ${servers.length} MCP server${servers.length === 1 ? "" : "s"}...\n`,
+					),
+				);
+			}
+			mcpMeasurements = await measureMcpServers(servers, {
+				timeoutMs: mcpTimeout,
+			});
+			mcpSources = mcpToSources(mcpMeasurements);
+		}
+	}
+
 	const alwaysLoaded = [
 		...claudeMdSources,
 		...contextFileSources,
 		...memorySources,
 		...skillMetadata,
+		...mcpSources,
 	];
 
 	const totalAlwaysChars = alwaysLoaded.reduce((sum, s) => sum + s.chars, 0);
 	const totalAlwaysTokens = charsToTokens(totalAlwaysChars);
 
 	const claudeMdTokens = charsToTokens(
-		[...claudeMdSources, ...contextFileSources].reduce((s, c) => s + c.chars, 0),
+		[...claudeMdSources, ...contextFileSources].reduce(
+			(s, c) => s + c.chars,
+			0,
+		),
 	);
-	const memoryTokens = charsToTokens(memorySources.reduce((s, c) => s + c.chars, 0));
-	const metadataTokens = charsToTokens(skillMetadata.reduce((s, c) => s + c.chars, 0));
+	const memoryTokens = charsToTokens(
+		memorySources.reduce((s, c) => s + c.chars, 0),
+	);
+	const metadataTokens = charsToTokens(
+		skillMetadata.reduce((s, c) => s + c.chars, 0),
+	);
+	const mcpTokens = charsToTokens(mcpSources.reduce((s, c) => s + c.chars, 0));
+
+	const currentSources: BaselineSource[] = alwaysLoaded.map((s) => ({
+		name: s.name,
+		type: s.type,
+		tokens: s.tokens,
+	}));
+
+	const diff = compareName
+		? (() => {
+				const stored = loadBaseline(compareName, cwd);
+				return stored ? diffBaseline(stored, currentSources) : null;
+			})()
+		: null;
+	const compareMissing = Boolean(compareName) && !diff;
 
 	const firstCallCost = costPerMTok(totalAlwaysTokens, pricing.cacheWrite);
 	const cachedCallCost = costPerMTok(totalAlwaysTokens, pricing.cacheRead);
@@ -237,71 +376,152 @@ export async function runContextCommand(): Promise<void> {
 	const sessionCostCached = firstCallCost + cachedCallCost * (avgTurns - 1);
 	const sessionCostUncached = uncachedCallCost * avgTurns;
 
+	if (saveName) {
+		saveBaseline({
+			name: saveName,
+			createdAt: new Date().toISOString(),
+			cwd,
+			totalTokens: totalAlwaysTokens,
+			sources: currentSources,
+		});
+	}
+
 	if (isJson) {
-		console.log(JSON.stringify({
-			model,
-			avg_turns: avgTurns,
-			always_loaded: {
-				total_chars: totalAlwaysChars,
-				total_tokens: totalAlwaysTokens,
-				claude_md_tokens: claudeMdTokens,
-				memory_tokens: memoryTokens,
-				skill_metadata_tokens: metadataTokens,
-			},
-			cost_per_call: {
-				first_call_cache_write: firstCallCost,
-				subsequent_cache_read: cachedCallCost,
-				uncached: uncachedCallCost,
-			},
-			session_estimate: {
-				with_cache: sessionCostCached,
-				without_cache: sessionCostUncached,
-				savings_pct: ((1 - sessionCostCached / sessionCostUncached) * 100),
-			},
-			sources: alwaysLoaded.map((s) => ({
-				name: s.name,
-				type: s.type,
-				chars: s.chars,
-				tokens: s.tokens,
-			})),
-			skill_bodies: skillBodies
-				.sort((a, b) => b.tokens - a.tokens)
-				.slice(0, 10)
-				.map((s) => ({ name: s.name, tokens: s.tokens })),
-		}, null, 2));
+		console.log(
+			JSON.stringify(
+				{
+					model,
+					avg_turns: avgTurns,
+					always_loaded: {
+						total_chars: totalAlwaysChars,
+						total_tokens: totalAlwaysTokens,
+						claude_md_tokens: claudeMdTokens,
+						memory_tokens: memoryTokens,
+						skill_metadata_tokens: metadataTokens,
+						mcp_tokens: mcpTokens,
+					},
+					mcp: withMcp
+						? {
+								measured: mcpMeasurements.filter((m) => m.status === "ok")
+									.length,
+								total: mcpMeasurements.length,
+								servers: mcpMeasurements.map((m) => ({
+									name: m.name,
+									scope: m.scope,
+									transport: m.transport,
+									status: m.status,
+									tool_count: m.toolCount,
+									tokens: charsToTokens(m.chars),
+									reason: m.reason,
+								})),
+							}
+						: null,
+					baseline_saved: saveName ?? null,
+					comparison: diff
+						? {
+								baseline: diff.baseline.name,
+								baseline_created_at: diff.baseline.createdAt,
+								total_before: diff.totalBefore,
+								total_after: diff.totalAfter,
+								total_delta: diff.totalDelta,
+								pct_delta: diff.pctDelta,
+								changes: diff.changes.map((c) => ({
+									name: c.name,
+									type: c.type,
+									kind: c.kind,
+									before: c.before,
+									after: c.after,
+									delta: c.delta,
+								})),
+							}
+						: null,
+					cost_per_call: {
+						first_call_cache_write: firstCallCost,
+						subsequent_cache_read: cachedCallCost,
+						uncached: uncachedCallCost,
+					},
+					session_estimate: {
+						with_cache: sessionCostCached,
+						without_cache: sessionCostUncached,
+						savings_pct: (1 - sessionCostCached / sessionCostUncached) * 100,
+					},
+					sources: alwaysLoaded.map((s) => ({
+						name: s.name,
+						type: s.type,
+						chars: s.chars,
+						tokens: s.tokens,
+					})),
+					skill_bodies: skillBodies
+						.sort((a, b) => b.tokens - a.tokens)
+						.slice(0, 10)
+						.map((s) => ({ name: s.name, tokens: s.tokens })),
+				},
+				null,
+				2,
+			),
+		);
 		return;
 	}
 
 	console.log("");
-	console.log(`  ${bold("CONTEXT TAX")} ${dim(`— ${model} pricing, ${avgTurns} turns/session`)}`);
+	console.log(
+		`  ${bold("CONTEXT TAX")} ${dim(`— ${model} pricing, ${avgTurns} turns/session`)}`,
+	);
 	console.log("");
 
 	const w = 28;
 	console.log(`    ${bold("ALWAYS LOADED")} ${dim("(every API call)")}`);
-	console.log(`    ${"CLAUDE.md + refs".padEnd(w)} ${formatTokens(claudeMdTokens).padStart(8)} tokens   ${dim(formatCost(costPerMTok(claudeMdTokens, pricing.cacheRead)))}`);
-	console.log(`    ${"Skills metadata".padEnd(w)} ${formatTokens(metadataTokens).padStart(8)} tokens   ${dim(formatCost(costPerMTok(metadataTokens, pricing.cacheRead)))}`);
+	console.log(
+		`    ${"CLAUDE.md + refs".padEnd(w)} ${formatTokens(claudeMdTokens).padStart(8)} tokens   ${dim(formatCost(costPerMTok(claudeMdTokens, pricing.cacheRead)))}`,
+	);
+	console.log(
+		`    ${"Skills metadata".padEnd(w)} ${formatTokens(metadataTokens).padStart(8)} tokens   ${dim(formatCost(costPerMTok(metadataTokens, pricing.cacheRead)))}`,
+	);
 	if (memoryTokens > 0) {
-		console.log(`    ${"Memory (MEMORY.md)".padEnd(w)} ${formatTokens(memoryTokens).padStart(8)} tokens   ${dim(formatCost(costPerMTok(memoryTokens, pricing.cacheRead)))}`);
+		console.log(
+			`    ${"Memory (MEMORY.md)".padEnd(w)} ${formatTokens(memoryTokens).padStart(8)} tokens   ${dim(formatCost(costPerMTok(memoryTokens, pricing.cacheRead)))}`,
+		);
+	}
+	if (mcpTokens > 0) {
+		console.log(
+			`    ${"MCP tool schemas".padEnd(w)} ${formatTokens(mcpTokens).padStart(8)} tokens   ${dim(formatCost(costPerMTok(mcpTokens, pricing.cacheRead)))}`,
+		);
 	}
 	console.log(`    ${"─".repeat(w + 25)}`);
-	console.log(`    ${bold("Total".padEnd(w))} ${bold(formatTokens(totalAlwaysTokens).padStart(8))} tokens   ${dim(formatCost(cachedCallCost))}${dim("/call (cached)")}`);
+	console.log(
+		`    ${bold("Total".padEnd(w))} ${bold(formatTokens(totalAlwaysTokens).padStart(8))} tokens   ${dim(formatCost(cachedCallCost))}${dim("/call (cached)")}`,
+	);
 	console.log("");
 
 	console.log(`    ${bold("COST PER CALL")}`);
-	console.log(`    ${"1st call (cache write)".padEnd(w)} ${formatCost(firstCallCost)}`);
-	console.log(`    ${"Subsequent (cache read)".padEnd(w)} ${green(formatCost(cachedCallCost))}`);
-	console.log(`    ${"Without cache".padEnd(w)} ${red(formatCost(uncachedCallCost))}`);
+	console.log(
+		`    ${"1st call (cache write)".padEnd(w)} ${formatCost(firstCallCost)}`,
+	);
+	console.log(
+		`    ${"Subsequent (cache read)".padEnd(w)} ${green(formatCost(cachedCallCost))}`,
+	);
+	console.log(
+		`    ${"Without cache".padEnd(w)} ${red(formatCost(uncachedCallCost))}`,
+	);
 	console.log("");
 
 	console.log(`    ${bold("SESSION ESTIMATE")} ${dim(`(${avgTurns} turns)`)}`);
-	console.log(`    ${"With prompt caching".padEnd(w)} ${green(formatCost(sessionCostCached))}`);
-	console.log(`    ${"Without caching".padEnd(w)} ${red(formatCost(sessionCostUncached))}`);
-	const savingsPct = ((1 - sessionCostCached / sessionCostUncached) * 100).toFixed(0);
+	console.log(
+		`    ${"With prompt caching".padEnd(w)} ${green(formatCost(sessionCostCached))}`,
+	);
+	console.log(
+		`    ${"Without caching".padEnd(w)} ${red(formatCost(sessionCostUncached))}`,
+	);
+	const savingsPct = (
+		(1 - sessionCostCached / sessionCostUncached) *
+		100
+	).toFixed(0);
 	console.log(`    ${"Cache savings".padEnd(w)} ${green(`${savingsPct}%`)}`);
 	console.log("");
 
-	const sortedSources = [...claudeMdSources, ...contextFileSources]
-		.sort((a, b) => b.tokens - a.tokens);
+	const sortedSources = [...claudeMdSources, ...contextFileSources].sort(
+		(a, b) => b.tokens - a.tokens,
+	);
 
 	if (sortedSources.length > 0) {
 		console.log(`    ${bold("CLAUDE.MD BREAKDOWN")}`);
@@ -309,20 +529,26 @@ export async function runContextCommand(): Promise<void> {
 		for (const s of sortedSources.slice(0, 10)) {
 			const barLen = Math.round((s.tokens / maxTok) * 15);
 			const bar = "█".repeat(barLen) + "░".repeat(15 - barLen);
-			console.log(`    ${dim(s.name.padEnd(w))} ${cyan(bar)} ${formatTokens(s.tokens).padStart(6)}`);
+			console.log(
+				`    ${dim(s.name.padEnd(w))} ${cyan(bar)} ${formatTokens(s.tokens).padStart(6)}`,
+			);
 		}
 		console.log("");
 	}
 
 	const sortedMeta = [...skillMetadata].sort((a, b) => b.tokens - a.tokens);
 	if (sortedMeta.length > 0) {
-		console.log(`    ${bold("TOP SKILLS BY METADATA")} ${dim(`(${skillMetadata.length} total)`)}`);
+		console.log(
+			`    ${bold("TOP SKILLS BY METADATA")} ${dim(`(${skillMetadata.length} total)`)}`,
+		);
 		const topMeta = sortedMeta.slice(0, 8);
 		const maxMetaTok = Math.max(...topMeta.map((s) => s.tokens));
 		for (const s of topMeta) {
 			const barLen = Math.round((s.tokens / maxMetaTok) * 15);
 			const bar = "█".repeat(barLen) + "░".repeat(15 - barLen);
-			console.log(`    ${dim(s.name.padEnd(w))} ${cyan(bar)} ${formatTokens(s.tokens).padStart(6)}`);
+			console.log(
+				`    ${dim(s.name.padEnd(w))} ${cyan(bar)} ${formatTokens(s.tokens).padStart(6)}`,
+			);
 		}
 		if (sortedMeta.length > 8) {
 			console.log(`    ${dim(`+${sortedMeta.length - 8} more`)}`);
@@ -332,22 +558,128 @@ export async function runContextCommand(): Promise<void> {
 
 	const sortedBodies = [...skillBodies].sort((a, b) => b.tokens - a.tokens);
 	if (sortedBodies.length > 0) {
-		console.log(`    ${bold("TOP SKILLS BY BODY")} ${dim("(loaded on trigger)")}`);
+		console.log(
+			`    ${bold("TOP SKILLS BY BODY")} ${dim("(loaded on trigger)")}`,
+		);
 		const topBodies = sortedBodies.slice(0, 5);
 		const maxBodyTok = Math.max(...topBodies.map((s) => s.tokens));
 		for (const s of topBodies) {
 			const barLen = Math.round((s.tokens / maxBodyTok) * 15);
 			const bar = "█".repeat(barLen) + "░".repeat(15 - barLen);
-			console.log(`    ${dim(s.name.padEnd(w))} ${cyan(bar)} ${formatTokens(s.tokens).padStart(6)}`);
+			console.log(
+				`    ${dim(s.name.padEnd(w))} ${cyan(bar)} ${formatTokens(s.tokens).padStart(6)}`,
+			);
 		}
 		console.log("");
 	}
 
+	if (withMcp && mcpMeasurements.length > 0) {
+		const ok = mcpMeasurements.filter((m) => m.status === "ok");
+		const failed = mcpMeasurements.filter((m) => m.status !== "ok");
+
+		console.log(
+			`    ${bold("MCP SERVERS")} ${dim(`(${ok.length}/${mcpMeasurements.length} measured)`)}`,
+		);
+		const sortedMcp = [...ok].sort((a, b) => b.chars - a.chars);
+		if (sortedMcp.length > 0) {
+			const maxMcpChars = Math.max(...sortedMcp.map((m) => m.chars));
+			for (const m of sortedMcp) {
+				const barLen = Math.round((m.chars / maxMcpChars) * 15);
+				const bar = "█".repeat(barLen) + "░".repeat(15 - barLen);
+				const label = `${m.name} ${dim(`(${m.toolCount})`)}`;
+				const pad = Math.max(
+					0,
+					w - m.name.length - String(m.toolCount).length - 3,
+				);
+				console.log(
+					`    ${dim(label)}${" ".repeat(pad)} ${cyan(bar)} ${formatTokens(charsToTokens(m.chars)).padStart(6)}`,
+				);
+			}
+		}
+		for (const m of failed) {
+			console.log(
+				`    ${dim(m.name.padEnd(w))} ${yellow("unmeasured")} ${dim(m.reason ?? m.status)}`,
+			);
+		}
+		console.log("");
+	} else if (withMcp) {
+		console.log(`    ${dim("No MCP servers configured for this directory.")}`);
+		console.log("");
+	}
+
+	if (compareMissing) {
+		console.log(
+			`    ${yellow("!")} No baseline named "${compareName}" for this directory`,
+		);
+		console.log(
+			`      ${dim("Save one with:")} skillkit context --save-baseline ${compareName}`,
+		);
+		console.log("");
+	}
+
+	if (diff) {
+		const sign = diff.totalDelta >= 0 ? "+" : "";
+		const deltaColor =
+			diff.totalDelta > 0 ? red : diff.totalDelta < 0 ? green : dim;
+		console.log(
+			`    ${bold("CONTEXT DRIFT")} ${dim(`(vs "${diff.baseline.name}", ${formatRelativeAge(diff.baseline.createdAt)})`)}`,
+		);
+		console.log(
+			`    ${"Total".padEnd(w)} ${formatTokens(diff.totalBefore)} → ${bold(formatTokens(diff.totalAfter))}   ${deltaColor(`${sign}${formatTokens(Math.abs(diff.totalDelta))} (${sign}${diff.pctDelta.toFixed(0)}%)`)}`,
+		);
+		if (diff.changes.length === 0) {
+			console.log(`    ${dim("No per-source changes.")}`);
+		} else {
+			console.log("");
+			for (const c of diff.changes.slice(0, 12)) {
+				const marker =
+					c.kind === "added"
+						? green("+")
+						: c.kind === "removed"
+							? red("-")
+							: dim("~");
+				const dSign = c.delta >= 0 ? "+" : "";
+				const dColor = c.delta > 0 ? red : green;
+				const detail =
+					c.kind === "changed"
+						? `${formatTokens(c.before)} → ${formatTokens(c.after)}`
+						: c.kind === "added"
+							? dim("new")
+							: dim("gone");
+				console.log(
+					`    ${marker} ${c.name.padEnd(w - 2)} ${detail.padStart(16)}   ${dColor(`${dSign}${formatTokens(Math.abs(c.delta))}`)}`,
+				);
+			}
+			if (diff.changes.length > 12) {
+				console.log(`    ${dim(`+${diff.changes.length - 12} more changes`)}`);
+			}
+		}
+		console.log("");
+	}
+
+	if (saveName) {
+		console.log(
+			`    ${green("✓")} Baseline "${saveName}" saved (${formatTokens(totalAlwaysTokens)} tokens)`,
+		);
+		console.log("");
+	}
+
+	if (!withMcp && discoverMcpServers(cwd).length > 0) {
+		console.log(
+			`    ${dim("MCP servers detected but not measured. Run with --mcp to include them.")}`,
+		);
+		console.log("");
+	}
+
 	if (totalAlwaysTokens > 15000) {
-		console.log(`    ${red("!")} Context tax is ${formatTokens(totalAlwaysTokens)} tokens — consider trimming CLAUDE.md or pruning unused skills`);
+		console.log(
+			`    ${red("!")} Context tax is ${formatTokens(totalAlwaysTokens)} tokens — consider trimming CLAUDE.md or pruning unused skills`,
+		);
 		console.log("");
 	} else if (totalAlwaysTokens > 8000) {
-		console.log(`    ${yellow("!")} Context tax is ${formatTokens(totalAlwaysTokens)} tokens — room to optimize`);
+		console.log(
+			`    ${yellow("!")} Context tax is ${formatTokens(totalAlwaysTokens)} tokens — room to optimize`,
+		);
 		console.log("");
 	}
 }

--- a/packages/cli/src/context/baseline.ts
+++ b/packages/cli/src/context/baseline.ts
@@ -1,0 +1,225 @@
+import type { Database } from "bun:sqlite";
+import { getDb } from "../db/schema";
+
+export interface BaselineSource {
+	name: string;
+	type: string;
+	tokens: number;
+}
+
+export interface BaselineSnapshot {
+	name: string;
+	createdAt: string;
+	cwd: string;
+	totalTokens: number;
+	sources: BaselineSource[];
+}
+
+export interface SourceDelta {
+	name: string;
+	type: string;
+	before: number;
+	after: number;
+	delta: number;
+	kind: "added" | "removed" | "changed";
+}
+
+export interface BaselineDiff {
+	baseline: BaselineSnapshot;
+	totalBefore: number;
+	totalAfter: number;
+	totalDelta: number;
+	pctDelta: number;
+	changes: SourceDelta[];
+}
+
+export function ensureBaselineTable(db: Database): void {
+	db.run(`
+		CREATE TABLE IF NOT EXISTS context_baselines (
+			name TEXT NOT NULL,
+			cwd TEXT NOT NULL,
+			created_at TEXT NOT NULL,
+			total_tokens INTEGER NOT NULL,
+			sources_json TEXT NOT NULL,
+			PRIMARY KEY (name, cwd)
+		)
+	`);
+}
+
+export function saveBaseline(snapshot: BaselineSnapshot): void {
+	const db = getDb();
+	ensureBaselineTable(db);
+	db.run(
+		`INSERT INTO context_baselines (name, cwd, created_at, total_tokens, sources_json)
+		 VALUES (?, ?, ?, ?, ?)
+		 ON CONFLICT(name, cwd) DO UPDATE SET
+		   created_at = excluded.created_at,
+		   total_tokens = excluded.total_tokens,
+		   sources_json = excluded.sources_json`,
+		[
+			snapshot.name,
+			snapshot.cwd,
+			snapshot.createdAt,
+			snapshot.totalTokens,
+			JSON.stringify(snapshot.sources),
+		],
+	);
+	db.close();
+}
+
+interface BaselineRow {
+	name: string;
+	cwd: string;
+	created_at: string;
+	total_tokens: number;
+	sources_json: string;
+}
+
+function rowToSnapshot(row: BaselineRow): BaselineSnapshot {
+	let sources: BaselineSource[] = [];
+	try {
+		sources = JSON.parse(row.sources_json) as BaselineSource[];
+	} catch {}
+	return {
+		name: row.name,
+		cwd: row.cwd,
+		createdAt: row.created_at,
+		totalTokens: row.total_tokens,
+		sources,
+	};
+}
+
+export function loadBaseline(
+	name: string,
+	cwd: string,
+): BaselineSnapshot | null {
+	const db = getDb();
+	ensureBaselineTable(db);
+	const row = db
+		.query("SELECT * FROM context_baselines WHERE name = ? AND cwd = ?")
+		.get(name, cwd) as BaselineRow | null;
+	db.close();
+	return row ? rowToSnapshot(row) : null;
+}
+
+export function listBaselines(cwd?: string): BaselineSnapshot[] {
+	const db = getDb();
+	ensureBaselineTable(db);
+	const rows = (
+		cwd
+			? db
+					.query(
+						"SELECT * FROM context_baselines WHERE cwd = ? ORDER BY created_at DESC",
+					)
+					.all(cwd)
+			: db
+					.query("SELECT * FROM context_baselines ORDER BY created_at DESC")
+					.all()
+	) as BaselineRow[];
+	db.close();
+	return rows.map(rowToSnapshot);
+}
+
+export function deleteBaseline(name: string, cwd: string): boolean {
+	const db = getDb();
+	ensureBaselineTable(db);
+	const before =
+		(
+			db
+				.query(
+					"SELECT COUNT(*) as n FROM context_baselines WHERE name = ? AND cwd = ?",
+				)
+				.get(name, cwd) as { n: number } | null
+		)?.n ?? 0;
+	db.run("DELETE FROM context_baselines WHERE name = ? AND cwd = ?", [
+		name,
+		cwd,
+	]);
+	db.close();
+	return before > 0;
+}
+
+/**
+ * Diff a stored baseline against a fresh measurement.
+ *
+ * Sources are keyed by `type:name` so a file and a skill sharing a name never
+ * collide, and so sources that appear or disappear between runs are surfaced
+ * rather than silently folded into the total.
+ */
+export function diffBaseline(
+	baseline: BaselineSnapshot,
+	current: BaselineSource[],
+): BaselineDiff {
+	const key = (s: BaselineSource) => `${s.type}:${s.name}`;
+
+	const beforeMap = new Map<string, BaselineSource>();
+	for (const s of baseline.sources) beforeMap.set(key(s), s);
+
+	const afterMap = new Map<string, BaselineSource>();
+	for (const s of current) afterMap.set(key(s), s);
+
+	const changes: SourceDelta[] = [];
+
+	for (const [k, after] of afterMap) {
+		const before = beforeMap.get(k);
+		if (!before) {
+			changes.push({
+				name: after.name,
+				type: after.type,
+				before: 0,
+				after: after.tokens,
+				delta: after.tokens,
+				kind: "added",
+			});
+		} else if (before.tokens !== after.tokens) {
+			changes.push({
+				name: after.name,
+				type: after.type,
+				before: before.tokens,
+				after: after.tokens,
+				delta: after.tokens - before.tokens,
+				kind: "changed",
+			});
+		}
+	}
+
+	for (const [k, before] of beforeMap) {
+		if (afterMap.has(k)) continue;
+		changes.push({
+			name: before.name,
+			type: before.type,
+			before: before.tokens,
+			after: 0,
+			delta: -before.tokens,
+			kind: "removed",
+		});
+	}
+
+	changes.sort((a, b) => Math.abs(b.delta) - Math.abs(a.delta));
+
+	const totalAfter = current.reduce((sum, s) => sum + s.tokens, 0);
+	const totalBefore = baseline.totalTokens;
+	const totalDelta = totalAfter - totalBefore;
+
+	return {
+		baseline,
+		totalBefore,
+		totalAfter,
+		totalDelta,
+		pctDelta: totalBefore > 0 ? (totalDelta / totalBefore) * 100 : 0,
+		changes,
+	};
+}
+
+export function formatRelativeAge(iso: string, now: Date = new Date()): string {
+	const then = new Date(iso).getTime();
+	if (Number.isNaN(then)) return "unknown";
+	const diffMs = now.getTime() - then;
+	const mins = Math.floor(diffMs / 60_000);
+	if (mins < 1) return "just now";
+	if (mins < 60) return `${mins}m ago`;
+	const hours = Math.floor(mins / 60);
+	if (hours < 24) return `${hours}h ago`;
+	const days = Math.floor(hours / 24);
+	return `${days}d ago`;
+}

--- a/packages/cli/src/db/queries.ts
+++ b/packages/cli/src/db/queries.ts
@@ -81,13 +81,15 @@ export function getInstalledSkills(db: Database): InstalledSkillRow[] {
 		.all();
 }
 
+// Callers pass null for "no session / no project / no agent" as readily as
+// they omit the argument, and the body already normalizes both to SQL NULL.
 export function recordInvocation(
 	db: Database,
 	skillName: string,
-	sessionId?: string,
-	project?: string,
-	timestamp?: string,
-	agent?: string,
+	sessionId?: string | null,
+	project?: string | null,
+	timestamp?: string | null,
+	agent?: string | null,
 ): void {
 	const ts = timestamp ?? new Date().toISOString();
 	db.run(

--- a/packages/cli/src/scanner/mcp.ts
+++ b/packages/cli/src/scanner/mcp.ts
@@ -1,0 +1,370 @@
+import { spawn } from "node:child_process";
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export type McpTransport = "stdio" | "http" | "sse" | "unknown";
+
+export type McpScope = "user" | "project" | "settings" | "mcp-json";
+
+export interface McpServerConfig {
+	name: string;
+	scope: McpScope;
+	transport: McpTransport;
+	command?: string;
+	args?: string[];
+	env?: Record<string, string>;
+	url?: string;
+}
+
+export type McpMeasureStatus = "ok" | "timeout" | "failed" | "unsupported";
+
+export interface McpServerMeasurement {
+	name: string;
+	scope: McpScope;
+	transport: McpTransport;
+	status: McpMeasureStatus;
+	toolCount: number;
+	chars: number;
+	reason?: string;
+}
+
+interface RawServerEntry {
+	type?: string;
+	transport?: string;
+	command?: string;
+	args?: string[];
+	env?: Record<string, string>;
+	url?: string;
+}
+
+function detectTransport(entry: RawServerEntry): McpTransport {
+	const declared = (entry.type ?? entry.transport ?? "").toLowerCase();
+	if (declared === "stdio" || declared === "http" || declared === "sse")
+		return declared;
+	if (entry.command) return "stdio";
+	if (entry.url) return "http";
+	return "unknown";
+}
+
+function toConfig(
+	name: string,
+	entry: RawServerEntry,
+	scope: McpScope,
+): McpServerConfig {
+	return {
+		name,
+		scope,
+		transport: detectTransport(entry),
+		command: entry.command,
+		args: entry.args,
+		env: entry.env,
+		url: entry.url,
+	};
+}
+
+function readJson(path: string): Record<string, unknown> | null {
+	if (!existsSync(path)) return null;
+	try {
+		return JSON.parse(readFileSync(path, "utf-8")) as Record<string, unknown>;
+	} catch {
+		return null;
+	}
+}
+
+function collectFrom(
+	raw: unknown,
+	scope: McpScope,
+	into: Map<string, McpServerConfig>,
+): void {
+	if (!raw || typeof raw !== "object") return;
+	for (const [name, entry] of Object.entries(
+		raw as Record<string, RawServerEntry>,
+	)) {
+		if (!entry || typeof entry !== "object") continue;
+		// Server names are matched case-insensitively so the same server
+		// declared as "alphaXiv" in one scope and "alphaxiv" in another is
+		// probed and billed once, not twice.
+		const key = name.toLowerCase();
+		if (into.has(key)) continue;
+		into.set(key, toConfig(name, entry, scope));
+	}
+}
+
+/**
+ * Discover MCP servers across every scope Claude Code reads.
+ *
+ * Precedence (first wins, matching Claude Code's own resolution order):
+ *   1. project scope   — ~/.claude.json -> .projects[cwd].mcpServers
+ *   2. repo scope      — <cwd>/.mcp.json -> .mcpServers
+ *   3. settings scope  — ~/.claude/settings.json -> .mcpServers
+ *   4. user scope      — ~/.claude.json -> .mcpServers
+ */
+export function discoverMcpServers(
+	cwd: string = process.cwd(),
+): McpServerConfig[] {
+	const found = new Map<string, McpServerConfig>();
+
+	const claudeJson = readJson(join(homedir(), ".claude.json"));
+
+	if (claudeJson) {
+		const projects = claudeJson.projects as
+			| Record<string, { mcpServers?: unknown }>
+			| undefined;
+		const projectEntry = projects?.[cwd];
+		collectFrom(projectEntry?.mcpServers, "project", found);
+	}
+
+	const repoMcpJson = readJson(join(cwd, ".mcp.json"));
+	collectFrom(repoMcpJson?.mcpServers, "mcp-json", found);
+
+	const settings = readJson(join(homedir(), ".claude", "settings.json"));
+	collectFrom(settings?.mcpServers, "settings", found);
+
+	collectFrom(claudeJson?.mcpServers, "user", found);
+
+	return [...found.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+interface JsonRpcMessage {
+	id?: number;
+	method?: string;
+	result?: { tools?: unknown[] };
+	error?: { message?: string };
+}
+
+/**
+ * A JSON-RPC *response* carries `result` or `error` and never `method`.
+ * Guarding on this matters: a server that echoes stdin back (or any pipe-like
+ * process such as `cat`) would otherwise replay our own requests, and the
+ * echoed `tools/list` would be read as a successful reply with zero tools —
+ * reporting a broken server as costing nothing.
+ */
+/**
+ * Pick the most explanatory line out of a server's stderr.
+ *
+ * The last line is often noise — a version banner, a runtime footer, a blank
+ * continuation — so prefer a line that actually reads like a failure, and fall
+ * back to the exit code rather than surfacing something misleading.
+ */
+export function pickFailureReason(stderr: string, code: number | null): string {
+	const lines = stderr
+		.split("\n")
+		.map((l) => l.trim())
+		.filter(Boolean);
+
+	const errorish =
+		/error|cannot|can't|not found|denied|refused|unsupported|required|missing|invalid|fatal|unauthorized|EACCES|ENOENT|throw/i;
+	const chosen = [...lines].reverse().find((l) => errorish.test(l)) ?? "";
+
+	if (!chosen) {
+		return code === null
+			? "server exited without output"
+			: `exited with code ${code}`;
+	}
+	return chosen.length > 160 ? `${chosen.slice(0, 157)}...` : chosen;
+}
+
+function isResponse(msg: JsonRpcMessage): boolean {
+	return (
+		msg.method === undefined &&
+		(msg.result !== undefined || msg.error !== undefined)
+	);
+}
+
+/**
+ * Measure one stdio MCP server by performing a real handshake and reading
+ * back its tool definitions. Tool schemas do not exist on disk — they are
+ * only produced at runtime — so this spawns the server, asks for tools/list,
+ * and tears it down.
+ *
+ * Never returns a fabricated 0: a server that fails, times out, or cannot be
+ * spoken to is reported with a non-"ok" status so callers can label it as
+ * unmeasured rather than free.
+ */
+export function measureMcpServer(
+	config: McpServerConfig,
+	timeoutMs = 20_000,
+): Promise<McpServerMeasurement> {
+	const base: McpServerMeasurement = {
+		name: config.name,
+		scope: config.scope,
+		transport: config.transport,
+		status: "unsupported",
+		toolCount: 0,
+		chars: 0,
+	};
+
+	if (config.transport !== "stdio" || !config.command) {
+		return Promise.resolve({
+			...base,
+			reason:
+				config.transport === "unknown"
+					? "unrecognized transport"
+					: `${config.transport} transport not measurable offline`,
+		});
+	}
+
+	return new Promise((resolve) => {
+		let child: ReturnType<typeof spawn>;
+		try {
+			child = spawn(config.command as string, config.args ?? [], {
+				stdio: ["pipe", "pipe", "pipe"],
+				env: { ...process.env, ...config.env },
+			});
+		} catch (err) {
+			resolve({ ...base, status: "failed", reason: (err as Error).message });
+			return;
+		}
+
+		let settled = false;
+		let buffer = "";
+		let stderrTail = "";
+
+		const finish = (result: McpServerMeasurement) => {
+			if (settled) return;
+			settled = true;
+			clearTimeout(timer);
+			try {
+				child.kill("SIGTERM");
+			} catch {}
+			resolve(result);
+		};
+
+		const timer = setTimeout(() => {
+			finish({
+				...base,
+				status: "timeout",
+				reason: `no tools/list response in ${Math.round(timeoutMs / 1000)}s`,
+			});
+		}, timeoutMs);
+
+		const send = (msg: unknown) => {
+			try {
+				child.stdin?.write(`${JSON.stringify(msg)}\n`);
+			} catch {}
+		};
+
+		child.stdout?.on("data", (chunk: Buffer) => {
+			buffer += chunk.toString();
+			let idx = buffer.indexOf("\n");
+			while (idx >= 0) {
+				const line = buffer.slice(0, idx).trim();
+				buffer = buffer.slice(idx + 1);
+				idx = buffer.indexOf("\n");
+				if (!line) continue;
+
+				let msg: JsonRpcMessage;
+				try {
+					msg = JSON.parse(line) as JsonRpcMessage;
+				} catch {
+					continue;
+				}
+
+				if (!isResponse(msg)) continue;
+
+				if (msg.id === 1) {
+					if (msg.error) {
+						finish({
+							...base,
+							status: "failed",
+							reason: msg.error.message ?? "initialize failed",
+						});
+						return;
+					}
+					send({ jsonrpc: "2.0", method: "notifications/initialized" });
+					send({ jsonrpc: "2.0", id: 2, method: "tools/list", params: {} });
+				}
+
+				if (msg.id === 2) {
+					if (msg.error) {
+						finish({
+							...base,
+							status: "failed",
+							reason: msg.error.message ?? "tools/list failed",
+						});
+						return;
+					}
+					const tools = msg.result?.tools;
+					if (!Array.isArray(tools)) {
+						finish({
+							...base,
+							status: "failed",
+							reason: "tools/list returned no tool list",
+						});
+						return;
+					}
+					finish({
+						...base,
+						status: "ok",
+						toolCount: tools.length,
+						chars: JSON.stringify(tools).length,
+					});
+					return;
+				}
+			}
+		});
+
+		child.stderr?.on("data", (chunk: Buffer) => {
+			stderrTail = (stderrTail + chunk.toString()).slice(-300);
+		});
+
+		child.on("error", (err) => {
+			finish({ ...base, status: "failed", reason: err.message });
+		});
+
+		child.on("exit", (code) => {
+			if (settled) return;
+			finish({
+				...base,
+				status: "failed",
+				reason: pickFailureReason(stderrTail, code),
+			});
+		});
+
+		send({
+			jsonrpc: "2.0",
+			id: 1,
+			method: "initialize",
+			params: {
+				protocolVersion: "2024-11-05",
+				capabilities: {},
+				clientInfo: { name: "skillkit", version: "0.11.0" },
+			},
+		});
+	});
+}
+
+/** Measure servers with bounded concurrency so we never fork-bomb the machine. */
+export async function measureMcpServers(
+	configs: McpServerConfig[],
+	options: {
+		concurrency?: number;
+		timeoutMs?: number;
+		onProgress?: (done: number, total: number) => void;
+	} = {},
+): Promise<McpServerMeasurement[]> {
+	const { concurrency = 4, timeoutMs = 20_000, onProgress } = options;
+	const results: McpServerMeasurement[] = new Array(configs.length);
+	let cursor = 0;
+	let done = 0;
+
+	const worker = async () => {
+		while (true) {
+			const index = cursor++;
+			const config = configs[index];
+			if (!config) return;
+			results[index] = await measureMcpServer(config, timeoutMs);
+			done++;
+			onProgress?.(done, configs.length);
+		}
+	};
+
+	await Promise.all(
+		Array.from({ length: Math.min(concurrency, configs.length) }, () =>
+			worker(),
+		),
+	);
+
+	return results;
+}


### PR DESCRIPTION
Closes #28, closes #29.

## Why

`skillkit context` measured CLAUDE.md, imports, skill metadata and memory, but not MCP servers. That turned out to be the largest missing slice.

Measured on the author's vault:

| | tokens |
|---|---|
| before (no MCP) | 18.8K |
| after (8 of 15 servers measured) | **64.8K** |

One server, `firecrawl` with 26 tools, costs 18.9K tokens by itself — more than the entire CLAUDE.md tree it was being compared against. Seven more servers could not be measured offline, so the real number is higher still.

## MCP measurement (#28)

Tool schemas do not exist on disk. Config files say how to *launch* a server; the definitions that consume context come back at runtime. There is no schema cache under `~/.claude` (checked). So measuring honestly means actually connecting:

```
spawn -> initialize -> notifications/initialized -> tools/list -> tokenize -> tear down
```

- Discovery spans all four scopes Claude Code reads: project and user scope in `~/.claude.json`, `~/.claude/settings.json`, and repo-level `.mcp.json`, deduped by name with scope recorded.
- Bounded concurrency (4) and a per-server timeout (`--mcp-timeout`, default 20s).
- **Never reports a fabricated zero.** A server that fails to start, times out, speaks a transport we cannot probe offline, or returns no tool list is labelled `unmeasured` with a reason. Reporting a broken server as costing nothing would be worse than reporting nothing at all.
- Opt-in behind `--mcp`, because it spawns processes.

```
MCP SERVERS (8/15 measured)
firecrawl (26)               ███████████████  18.9K
trigger (37)                 ██████████░░░░░  12.8K
google-calendar (13)         ███████░░░░░░░░   9.4K
...
context7                     unmeasured http transport not measurable offline
excalidraw                   unmeasured exited with code 1
```

## Baselines and drift (#29)

```
skillkit context --save-baseline pre-pack
skillkit context --mcp --compare pre-pack
```

```
CONTEXT DRIFT (vs "pre-pack", just now)
Total                        18.8K → 64.8K   +46.0K (+244%)

+ firecrawl                               new   +18.9K
+ trigger                                 new   +12.8K
+ google-calendar                         new   +9.4K
```

Stored in `~/.skillkit/analytics.db` alongside the rest of the analytics rather than loose JSON. Diffs are per-source, not just totals, so growth is attributable. Sources are keyed by `type:name`, so entries that appear or disappear surface as `added`/`removed` instead of silently folding into the total.

## Two bugs found while building this

- **Echoed requests read as valid responses.** A pipe-like process (`cat`, or any server that echoes stdin) replayed our own `tools/list` request, which the parser accepted as a reply with zero tools — exactly the silent zero this feature promised to avoid. Fixed by requiring a real JSON-RPC response shape (`result`/`error`, no `method`). A test covers it.
- **`--help` lied.** It advertised `sonnet` as the default pricing model for `context`; the code has always defaulted to `opus`.

## Caveats, stated plainly

- The tokenizer is `chars / 3.7` (unchanged, pre-existing). JSON schemas tokenize worse than prose, so MCP figures are approximate and should be read as an order of magnitude, not a precise count.
- `http`/`sse` and auth-gated servers cannot be probed offline and are reported as unmeasured, not as zero.
- Claude Code's tool-search / deferred-tools feature can defer MCP tools so they do not all load eagerly. What this measures is the eager worst case, which is the number worth knowing before deciding to defer.

## Verification

- `bun test src/` — 165 pass, 0 fail (26 new tests across two files; `context` previously had none)
- `tsc --noEmit` — 9 errors, identical to the count on clean `main`, none in the new files (verified by stashing)
- `biome check` — clean on all new and touched files
- Exercised end to end against 15 configured MCP servers, plus the full save/list/compare/delete baseline cycle

---

## Follow-up commit: three fixes found while reviewing this work

### `burn` reported NaN costs for most models

Only 7 of the 48 entries in `MODEL_PRICING` declare `cacheCreate`/`cacheRead`. For the other 41 — every GPT, Gemini, Grok, DeepSeek, Llama, Mistral and Cursor entry — those fields read as `undefined`, and `tokens * undefined` is `NaN`. That `NaN` then flowed into every running total it was added to, so one session of a non-Anthropic model with cache tokens voided the cost figures for the entire report.

`getPricing` now fills missing cache prices from the standard multipliers (write 1.25x input, read 0.1x) and returns a type where all four cost fields are guaranteed present, so the hole cannot reopen. Verified against real Cursor session data: zero NaN in the output.

### `context` double-counted some imports and missed others

A file imported by two different CLAUDE.md files was counted once per referrer, inflating the tax. Imports nested inside imported files were not counted at all, understating it. Resolution now dedupes by resolved path and follows the closure transitively, with a depth cap and a visited set so a cycle terminates instead of recursing forever.

### tsc: 9 errors to 0

`recordInvocation` accepted `string | undefined` while every caller passes `null` for "no project" — which the body already normalized to SQL NULL. The signature now says so, rather than 7 tests asserting around it. Also dropped three unused imports in `context.ts`.

These were the errors this PR had been reporting as "preexisting on main". They are gone.

**Verification after the follow-up:** 176 tests pass (11 more), `tsc --noEmit` clean at 0 errors, `context` and `burn` both exercised end to end. Formatting of untouched files is deliberately left alone so the diff stays reviewable.
