### PR TITLE
fix(scanner): dedupe invocations by stable event id

### DIFF
--- a/packages/cli/src/__tests__/amp-parser.test.ts
+++ b/packages/cli/src/__tests__/amp-parser.test.ts
@@ -240,7 +240,8 @@ describe("countAmpSessions / scanAmpSessions", () => {
 			session_id TEXT,
 			project TEXT,
 			success INTEGER DEFAULT 1,
-			agent TEXT
+			agent TEXT,
+			event_id TEXT
 		)`);
 		db.run(`CREATE TABLE IF NOT EXISTS skill_daily_stats (
 			date TEXT NOT NULL,

--- a/packages/cli/src/__tests__/dedupe.test.ts
+++ b/packages/cli/src/__tests__/dedupe.test.ts
@@ -1,0 +1,324 @@
+import { Database } from "bun:sqlite";
+import { beforeEach, describe, expect, it } from "bun:test";
+import {
+	eventKey,
+	getTrackedSet,
+	type Invocation,
+	recordNewInvocations,
+	timestampKey,
+} from "../scanner";
+
+function freshDb(): Database {
+	const db = new Database(":memory:");
+	db.run(`
+		CREATE TABLE skill_invocations (
+			id INTEGER PRIMARY KEY AUTOINCREMENT,
+			skill_name TEXT NOT NULL,
+			timestamp TEXT NOT NULL,
+			session_id TEXT,
+			project TEXT,
+			success INTEGER DEFAULT 1,
+			agent TEXT,
+			event_id TEXT
+		)
+	`);
+	db.run(`
+		CREATE TABLE skill_daily_stats (
+			date TEXT NOT NULL,
+			skill_name TEXT NOT NULL,
+			count INTEGER DEFAULT 0,
+			UNIQUE(date, skill_name)
+		)
+	`);
+	return db;
+}
+
+function rows(db: Database) {
+	return db
+		.query(
+			"SELECT skill_name, timestamp, session_id, event_id FROM skill_invocations",
+		)
+		.all() as Array<{
+		skill_name: string;
+		timestamp: string;
+		session_id: string | null;
+		event_id: string | null;
+	}>;
+}
+
+describe("recordNewInvocations", () => {
+	let db: Database;
+	beforeEach(() => {
+		db = freshDb();
+	});
+
+	it("records a new invocation and persists its event id", () => {
+		const inv: Invocation = {
+			skillName: "research",
+			timestamp: "2026-07-26T10:00:00.000Z",
+			sessionId: "s1",
+			agent: "claude",
+			eventId: "toolu_01abc",
+		};
+
+		expect(recordNewInvocations(db, new Set(), [inv])).toBe(1);
+		expect(rows(db)).toHaveLength(1);
+		expect(rows(db)[0]?.event_id).toBe("toolu_01abc");
+	});
+
+	// The bug this fixes: one connector seeing the same event through two
+	// stores with different timestamp fidelity used to insert it twice,
+	// because the key was skillName::timestamp and the timestamps differed.
+	it("dedupes one event seen twice with timestamps more than a second apart", () => {
+		const tracked = new Set<string>();
+		const first: Invocation = {
+			skillName: "research",
+			timestamp: "2026-07-26T10:00:00.000Z",
+			sessionId: "s1",
+			eventId: "call_xyz",
+		};
+		const second: Invocation = {
+			...first,
+			timestamp: "2026-07-26T10:00:47.000Z",
+		};
+
+		expect(recordNewInvocations(db, tracked, [first])).toBe(1);
+		expect(recordNewInvocations(db, tracked, [second])).toBe(0);
+		expect(rows(db)).toHaveLength(1);
+	});
+
+	it("still dedupes by timestamp when no event id is present", () => {
+		const tracked = new Set<string>();
+		const inv: Invocation = {
+			skillName: "research",
+			timestamp: "2026-07-26T10:00:00.000Z",
+			sessionId: "s1",
+		};
+
+		expect(recordNewInvocations(db, tracked, [inv])).toBe(1);
+		expect(recordNewInvocations(db, tracked, [inv])).toBe(0);
+		expect(rows(db)).toHaveLength(1);
+	});
+
+	// Tool-call ids are only unique within a session, so the event key is
+	// session-scoped. Two sessions reusing an id are two invocations.
+	it("treats the same event id in two sessions as two invocations", () => {
+		const tracked = new Set<string>();
+		const a: Invocation = {
+			skillName: "research",
+			timestamp: "2026-07-26T10:00:00.000Z",
+			sessionId: "s1",
+			eventId: "call_1",
+		};
+		// Different time as well: the timestamp key is global, and collapsing
+		// two same-instant invocations is pre-existing behaviour this change
+		// deliberately preserves (no such pair exists in practice).
+		const b: Invocation = {
+			...a,
+			sessionId: "s2",
+			timestamp: "2026-07-26T10:00:05.000Z",
+		};
+
+		expect(recordNewInvocations(db, tracked, [a, b])).toBe(2);
+		expect(rows(db)).toHaveLength(2);
+	});
+
+	it("collapses two invocations that share a skill and instant", () => {
+		const tracked = new Set<string>();
+		const ts = "2026-07-26T10:00:00.000Z";
+
+		// Pre-existing behaviour, kept intentionally: the timestamp key is not
+		// session-scoped. Verified against real data, where no such pair occurs.
+		const n = recordNewInvocations(db, tracked, [
+			{ skillName: "research", timestamp: ts, sessionId: "s1" },
+			{ skillName: "research", timestamp: ts, sessionId: "s2" },
+		]);
+
+		expect(n).toBe(1);
+	});
+
+	it("keeps distinct skills at the same timestamp", () => {
+		const tracked = new Set<string>();
+		const ts = "2026-07-26T10:00:00.000Z";
+
+		const n = recordNewInvocations(db, tracked, [
+			{ skillName: "research", timestamp: ts, sessionId: "s1" },
+			{ skillName: "deslop", timestamp: ts, sessionId: "s1" },
+		]);
+
+		expect(n).toBe(2);
+	});
+
+	// A row written with an id must still be recognized by a later scan that
+	// cannot recover one, otherwise the fallback path would duplicate it.
+	it("does not re-insert an id-tracked row when a later scan has no id", () => {
+		const tracked = new Set<string>();
+		const withId: Invocation = {
+			skillName: "research",
+			timestamp: "2026-07-26T10:00:00.000Z",
+			sessionId: "s1",
+			eventId: "call_1",
+		};
+
+		expect(recordNewInvocations(db, tracked, [withId])).toBe(1);
+
+		const { eventId: _dropped, ...withoutId } = withId;
+		expect(recordNewInvocations(db, tracked, [withoutId])).toBe(0);
+		expect(rows(db)).toHaveLength(1);
+	});
+
+	// Rows written before any connector reported ids are tracked only by their
+	// timestamp key. When a connector later learns to report an id, the same
+	// invocation must not be inserted a second time.
+	it("does not duplicate a pre-existing row once the connector starts reporting ids", () => {
+		const tracked = new Set<string>();
+		const ts = "2026-07-26T10:00:00.000Z";
+
+		expect(
+			recordNewInvocations(db, tracked, [
+				{ skillName: "research", timestamp: ts, sessionId: "s1" },
+			]),
+		).toBe(1);
+
+		// Same event, same time, but this scan can name it.
+		expect(
+			recordNewInvocations(db, tracked, [
+				{
+					skillName: "research",
+					timestamp: ts,
+					sessionId: "s1",
+					eventId: "call_1",
+				},
+			]),
+		).toBe(0);
+		expect(rows(db)).toHaveLength(1);
+	});
+
+	it("skips names that are not skills", () => {
+		const n = recordNewInvocations(db, new Set(), [
+			{
+				skillName: "mcp__firecrawl__search",
+				timestamp: "2026-07-26T10:00:00.000Z",
+				sessionId: "s1",
+			},
+		]);
+
+		expect(n).toBe(0);
+		expect(rows(db)).toHaveLength(0);
+	});
+});
+
+describe("getTrackedSet", () => {
+	it("tracks an id-bearing row under both its event key and its timestamp key", () => {
+		const db = freshDb();
+		recordNewInvocations(db, new Set(), [
+			{
+				skillName: "research",
+				timestamp: "2026-07-26T10:00:00.000Z",
+				sessionId: "s1",
+				eventId: "call_1",
+			},
+		]);
+
+		const tracked = getTrackedSet(db);
+
+		expect(tracked.has(eventKey("research", "s1", "call_1"))).toBe(true);
+		expect(
+			tracked.has(timestampKey("research", "2026-07-26T10:00:00.000Z")),
+		).toBe(true);
+	});
+
+	it("survives a scan across process restarts without duplicating", () => {
+		const db = freshDb();
+		const inv: Invocation = {
+			skillName: "research",
+			timestamp: "2026-07-26T10:00:00.000Z",
+			sessionId: "s1",
+			eventId: "call_1",
+		};
+
+		recordNewInvocations(db, getTrackedSet(db), [inv]);
+		// Second run rebuilds the set from the database, as a new process would.
+		recordNewInvocations(db, getTrackedSet(db), [
+			{ ...inv, timestamp: "2026-07-26T10:05:00.000Z" },
+		]);
+
+		expect(rows(db)).toHaveLength(1);
+	});
+});
+
+// A database created before the event_id migration must keep working: the
+// scanner should degrade to timestamp keys rather than throwing.
+describe("database predating the event_id column", () => {
+	function legacyDb(): Database {
+		const db = new Database(":memory:");
+		db.run(`
+			CREATE TABLE skill_invocations (
+				id INTEGER PRIMARY KEY AUTOINCREMENT,
+				skill_name TEXT NOT NULL,
+				timestamp TEXT NOT NULL,
+				session_id TEXT,
+				project TEXT,
+				success INTEGER DEFAULT 1,
+				agent TEXT
+			)
+		`);
+		db.run(`
+			CREATE TABLE skill_daily_stats (
+				date TEXT NOT NULL,
+				skill_name TEXT NOT NULL,
+				count INTEGER DEFAULT 0,
+				UNIQUE(date, skill_name)
+			)
+		`);
+		return db;
+	}
+
+	it("records an invocation that carries an event id without throwing", () => {
+		const db = legacyDb();
+
+		expect(() =>
+			recordNewInvocations(db, new Set(), [
+				{
+					skillName: "research",
+					timestamp: "2026-07-26T10:00:00.000Z",
+					sessionId: "s1",
+					eventId: "call_1",
+				},
+			]),
+		).not.toThrow();
+
+		expect(
+			db.query("SELECT COUNT(*) as n FROM skill_invocations").get(),
+		).toMatchObject({ n: 1 });
+	});
+
+	it("builds a tracked set from the legacy schema", () => {
+		const db = legacyDb();
+		recordNewInvocations(db, new Set(), [
+			{
+				skillName: "research",
+				timestamp: "2026-07-26T10:00:00.000Z",
+				sessionId: "s1",
+			},
+		]);
+
+		const tracked = getTrackedSet(db);
+
+		expect(
+			tracked.has(timestampKey("research", "2026-07-26T10:00:00.000Z")),
+		).toBe(true);
+	});
+});
+
+describe("key builders", () => {
+	it("scopes the event key by session", () => {
+		expect(eventKey("a", "s1", "e1")).not.toBe(eventKey("a", "s2", "e1"));
+	});
+
+	it("strips milliseconds in the timestamp key", () => {
+		expect(timestampKey("a", "2026-07-26T10:00:00.123Z")).toBe(
+			timestampKey("a", "2026-07-26T10:00:00.999Z"),
+		);
+	});
+});

--- a/packages/cli/src/__tests__/goose-parser.test.ts
+++ b/packages/cli/src/__tests__/goose-parser.test.ts
@@ -214,7 +214,8 @@ describe("scanGooseDb (sqlite)", () => {
 			session_id TEXT,
 			project TEXT,
 			success INTEGER DEFAULT 1,
-			agent TEXT
+			agent TEXT,
+			event_id TEXT
 		)`);
 		db.run(`CREATE TABLE IF NOT EXISTS skill_daily_stats (
 			date TEXT NOT NULL,

--- a/packages/cli/src/__tests__/queries.test.ts
+++ b/packages/cli/src/__tests__/queries.test.ts
@@ -22,7 +22,8 @@ function makeDb(): Database {
 		session_id TEXT,
 		project TEXT,
 		success INTEGER DEFAULT 1,
-		agent TEXT
+		agent TEXT,
+		event_id TEXT
 	)`);
 	db.run(`CREATE TABLE IF NOT EXISTS skill_daily_stats (
 		date TEXT NOT NULL,

--- a/packages/cli/src/db/queries.ts
+++ b/packages/cli/src/db/queries.ts
@@ -90,12 +90,29 @@ export function recordInvocation(
 	project?: string | null,
 	timestamp?: string | null,
 	agent?: string | null,
+	eventId?: string | null,
 ): void {
 	const ts = timestamp ?? new Date().toISOString();
-	db.run(
-		"INSERT INTO skill_invocations (skill_name, timestamp, session_id, project, agent) VALUES (?, ?, ?, ?, ?)",
-		[skillName, ts, sessionId ?? null, project ?? null, agent ?? null],
-	);
+	try {
+		db.run(
+			"INSERT INTO skill_invocations (skill_name, timestamp, session_id, project, agent, event_id) VALUES (?, ?, ?, ?, ?, ?)",
+			[
+				skillName,
+				ts,
+				sessionId ?? null,
+				project ?? null,
+				agent ?? null,
+				eventId ?? null,
+			],
+		);
+	} catch {
+		// A database that never went through getDb() has no event_id column.
+		// Recording the invocation matters more than recording its id.
+		db.run(
+			"INSERT INTO skill_invocations (skill_name, timestamp, session_id, project, agent) VALUES (?, ?, ?, ?, ?)",
+			[skillName, ts, sessionId ?? null, project ?? null, agent ?? null],
+		);
+	}
 	const date = ts.slice(0, 10);
 	db.run(
 		"INSERT INTO skill_daily_stats (date, skill_name, count) VALUES (?, ?, 1) ON CONFLICT(date, skill_name) DO UPDATE SET count = count + 1",

--- a/packages/cli/src/db/schema.ts
+++ b/packages/cli/src/db/schema.ts
@@ -45,6 +45,9 @@ export function getDb(): Database {
 		db.run("ALTER TABLE skill_invocations ADD COLUMN agent TEXT");
 	} catch {}
 	try {
+		db.run("ALTER TABLE skill_invocations ADD COLUMN event_id TEXT");
+	} catch {}
+	try {
 		db.run(
 			"UPDATE skill_invocations SET agent = 'opencode' WHERE (agent IS NULL OR agent = '') AND session_id LIKE 'oc:%'",
 		);

--- a/packages/cli/src/scanner/connectors/claude.ts
+++ b/packages/cli/src/scanner/connectors/claude.ts
@@ -11,6 +11,8 @@ interface ToolUseBlock {
 	type: "tool_use";
 	name: string;
 	input: Record<string, unknown>;
+	/** Anthropic tool-call id, e.g. "toolu_01...". Stable across re-scans. */
+	id?: string;
 }
 
 function extractSkillName(block: ToolUseBlock): string | null {
@@ -114,9 +116,16 @@ export function parseSessionFile(
 				block.type === "tool_use" &&
 				(block as unknown as ToolUseBlock).name === "Skill"
 			) {
-				const skillName = extractSkillName(block as unknown as ToolUseBlock);
+				const toolUse = block as unknown as ToolUseBlock;
+				const skillName = extractSkillName(toolUse);
 				if (skillName) {
-					results.push({ skillName, timestamp, sessionId, agent: "claude" });
+					results.push({
+						skillName,
+						timestamp,
+						sessionId,
+						agent: "claude",
+						eventId: toolUse.id,
+					});
 				}
 			}
 		}

--- a/packages/cli/src/scanner/connectors/codex.ts
+++ b/packages/cli/src/scanner/connectors/codex.ts
@@ -86,6 +86,10 @@ export function parseCodexSessionFile(
 				if (name === "exec_command") {
 					const args = (payload.arguments as string) ?? "";
 					const skillName = extractSkillFromArgs(args);
+					// This branch keeps only the first sighting of each skill per
+					// file, so the id recorded is that first command's call_id.
+					// It is stable across scans because the file is replayed in
+					// order, which is what the dedupe key needs.
 					if (skillName && !seenSkills.has(skillName)) {
 						seenSkills.add(skillName);
 						results.push({
@@ -93,6 +97,7 @@ export function parseCodexSessionFile(
 							timestamp,
 							sessionId,
 							agent: "codex",
+							eventId: payload.call_id as string | undefined,
 						});
 					}
 					continue;
@@ -106,6 +111,7 @@ export function parseCodexSessionFile(
 						timestamp,
 						sessionId,
 						agent: "codex",
+						eventId: payload.call_id as string | undefined,
 					});
 				}
 			}
@@ -125,6 +131,7 @@ export function parseCodexSessionFile(
 								timestamp,
 								sessionId,
 								agent: "codex",
+								eventId: (block.call_id ?? block.id) as string | undefined,
 							});
 						}
 					}

--- a/packages/cli/src/scanner/connectors/continue.ts
+++ b/packages/cli/src/scanner/connectors/continue.ts
@@ -209,6 +209,7 @@ export function parseContinueSessionFile(
 			timestamp,
 			sessionId,
 			agent: "continue",
+			eventId: callId,
 		});
 	};
 

--- a/packages/cli/src/scanner/connectors/kilocode.ts
+++ b/packages/cli/src/scanner/connectors/kilocode.ts
@@ -127,6 +127,7 @@ export function parseKiloPartData(
 			timestamp: new Date(timeCreated).toISOString(),
 			sessionId: `kilo:${sessionId}`,
 			agent: "kilocode",
+			eventId: typeof data.callID === "string" ? data.callID : undefined,
 		},
 	];
 }

--- a/packages/cli/src/scanner/connectors/opencode.ts
+++ b/packages/cli/src/scanner/connectors/opencode.ts
@@ -122,6 +122,8 @@ export function scanOpenCodeSessions(
 				timestamp: new Date(row.time_created).toISOString(),
 				sessionId: `oc:${row.session_id}`,
 				agent: "opencode",
+				eventId:
+					typeof data.callID === "string" ? data.callID : undefined,
 			});
 		}
 

--- a/packages/cli/src/scanner/connectors/openhands.ts
+++ b/packages/cli/src/scanner/connectors/openhands.ts
@@ -37,6 +37,16 @@ function extractSkillFromArgs(args: string): string | null {
 	return match ? (match[1] ?? null) : null;
 }
 
+/**
+ * Stable id for one event file.
+ *
+ * Both layouts name the file after the event, so the basename identifies the
+ * event even when the JSON carries no id of its own.
+ */
+function eventIdForEventFile(filePath: string): string {
+	return basename(filePath).replace(/\.json$/, "");
+}
+
 function sessionIdForEventFile(filePath: string): string {
 	const parent = dirname(filePath);
 	// CLI/SDK layout: <conversations>/<cid>/events/event-*.json
@@ -75,6 +85,8 @@ export function parseOpenHandsEventFile(
 			? obj.timestamp
 			: new Date().toISOString();
 	const kind = obj.kind as string | undefined;
+	const baseEventId =
+		typeof obj.id === "string" && obj.id ? obj.id : eventIdForEventFile(filePath);
 
 	if (kind === "MessageEvent") {
 		const activated = obj.activated_skills;
@@ -88,6 +100,7 @@ export function parseOpenHandsEventFile(
 					timestamp,
 					sessionId,
 					agent: "openhands",
+					eventId: `${baseEventId}#${name}`,
 				});
 			}
 		}
@@ -116,6 +129,7 @@ export function parseOpenHandsEventFile(
 				timestamp,
 				sessionId,
 				agent: "openhands",
+				eventId: baseEventId,
 			});
 			return results;
 		}
@@ -126,6 +140,7 @@ export function parseOpenHandsEventFile(
 				timestamp,
 				sessionId,
 				agent: "openhands",
+				eventId: baseEventId,
 			});
 		}
 	}

--- a/packages/cli/src/scanner/index.ts
+++ b/packages/cli/src/scanner/index.ts
@@ -52,24 +52,71 @@ export function isSkillName(name: string): boolean {
 	return true;
 }
 
-interface AlreadyTracked {
-	session_id: string;
-	timestamp: string;
-}
-
 function roundTs(ts: string): string {
 	return ts.replace(/\.\d{3}Z$/, "Z");
 }
 
+/**
+ * Dedupe key for a source that carries a stable per-event id.
+ *
+ * Scoped by session because tool-call ids are only unique within a session,
+ * not globally.
+ */
+export function eventKey(
+	skillName: string,
+	sessionId: string,
+	eventId: string,
+): string {
+	return `${skillName}::e:${sessionId}::${eventId}`;
+}
+
+/**
+ * Dedupe key for a source with no stable id, kept for backward compatibility.
+ *
+ * This key assumes timestamps are unique and stable across scans. Neither is
+ * guaranteed: a connector reading the same event from two stores can see it
+ * with different timestamp fidelity, and a source with no per-event time needs
+ * a synthetic one. Prefer eventKey wherever the source provides an id.
+ */
+export function timestampKey(skillName: string, timestamp: string): string {
+	return `${skillName}::${roundTs(timestamp)}`;
+}
+
 export function getTrackedSet(db: Database): Set<string> {
-	const tracked = db
-		.query<{ skill_name: string; timestamp: string }, []>(
-			"SELECT skill_name, timestamp FROM skill_invocations",
-		)
-		.all();
-	return new Set(
-		tracked.map((r) => `${r.skill_name}::${roundTs(r.timestamp)}`),
-	);
+	type TrackedRow = {
+		skill_name: string;
+		timestamp: string;
+		session_id: string | null;
+		event_id: string | null;
+	};
+
+	let tracked: TrackedRow[];
+	try {
+		tracked = db
+			.query<TrackedRow, []>(
+				"SELECT skill_name, timestamp, session_id, event_id FROM skill_invocations",
+			)
+			.all();
+	} catch {
+		// Database predating the event_id column; timestamp keys still apply.
+		tracked = db
+			.query<TrackedRow, []>(
+				"SELECT skill_name, timestamp, session_id, NULL as event_id FROM skill_invocations",
+			)
+			.all();
+	}
+
+	const keys = new Set<string>();
+	for (const r of tracked) {
+		// A row recorded with an event id is tracked under both keys: the strong
+		// one, and the timestamp one so a re-scan that cannot recover the id
+		// still recognizes the row instead of inserting a duplicate.
+		if (r.event_id && r.session_id) {
+			keys.add(eventKey(r.skill_name, r.session_id, r.event_id));
+		}
+		keys.add(timestampKey(r.skill_name, r.timestamp));
+	}
+	return keys;
 }
 
 export interface Invocation {
@@ -77,6 +124,12 @@ export interface Invocation {
 	timestamp: string;
 	sessionId: string;
 	agent?: string;
+	/**
+	 * Stable id for this event from the source itself (tool-call id, event id).
+	 * When present it is what identifies the invocation across scans, so a
+	 * source seen twice with drifting timestamps still dedupes.
+	 */
+	eventId?: string;
 }
 
 export function recordNewInvocations(
@@ -87,19 +140,37 @@ export function recordNewInvocations(
 	let count = 0;
 	for (const inv of invocations) {
 		if (!isSkillName(inv.skillName)) continue;
-		const key = `${inv.skillName}::${roundTs(inv.timestamp)}`;
-		if (!trackedSet.has(key)) {
-			recordInvocation(
-				db,
-				inv.skillName,
-				inv.sessionId,
-				undefined,
-				inv.timestamp,
-				inv.agent,
-			);
-			trackedSet.add(key);
-			count++;
-		}
+
+		const strongKey = inv.eventId
+			? eventKey(inv.skillName, inv.sessionId, inv.eventId)
+			: null;
+		const weakKey = timestampKey(inv.skillName, inv.timestamp);
+
+		// Either key matching means we already have this invocation.
+		//
+		// The event key catches what the timestamp key misses: two views of one
+		// event that disagree on the time. The timestamp key still has to be
+		// honoured even when an id is present, because rows recorded before ids
+		// existed are only tracked under it, and skipping that check would
+		// re-insert every one of them the first time a connector learns to
+		// report an id.
+		if (trackedSet.has(weakKey)) continue;
+		if (strongKey && trackedSet.has(strongKey)) continue;
+
+		const key = strongKey ?? weakKey;
+
+		recordInvocation(
+			db,
+			inv.skillName,
+			inv.sessionId,
+			undefined,
+			inv.timestamp,
+			inv.agent,
+			inv.eventId,
+		);
+		trackedSet.add(key);
+		if (strongKey) trackedSet.add(weakKey);
+		count++;
 	}
 	return count;
 }


### PR DESCRIPTION
Closes #27.

## The bug

Dedupe keyed on `skillName::roundTs(timestamp)`, which assumes timestamps are both unique and stable across scans. Neither holds. A connector that sees one event through two stores can read it with different timestamp fidelity, and a source with no per-event time needs a synthetic one. The per-connector workarounds in #26 fixed the reproduced symptoms; the class of bug survived.

## The fix

`Invocation` gains an optional `eventId` taken from the source's own identifier. Dedupe prefers `skillName::sessionId::eventId` when present, falling back to the timestamp key otherwise. The event key is session-scoped because tool-call ids are only unique within a session.

## Ids verified against real data, not assumed

The issue listed which sources carry ids. I checked each against actual session files on disk rather than trusting the format docs, because none of the parsers read these fields today:

| connector | field | verified |
|---|---|---|
| claude | `tool_use.id` | yes, `toolu_01...` in a real JSONL |
| codex | `payload.call_id` | yes, `call_...` in a real rollout |
| opencode | part `data.callID` | yes, queried the real sqlite |
| kilocode | part `data.callID` | same shape, documented in the connector |
| continue | `toolCallId` | already read, was discarded before the push |
| openhands | event id, filename fallback | per the connector's own path layout |

Copilot is named in the issue but is not installed here, so I did not wire a field I could not observe. Connectors whose data has no stable id (cursor, gemini, amp, goose, windsurf, cline, roo) keep the timestamp key unchanged.

## A regression this caught, worth calling out

My first version consulted the event key alone when an id was present. Scanning a real database doubled rows: entries written before ids existed are tracked only under the timestamp key, so the strong-key lookup missed them and re-inserted every one. Both keys are now checked before inserting, with a test covering exactly that transition.

A second scare turned out not to be mine. Codex row counts dropped by 92 after a full rescan, which looked like data loss from this change. Running the same scan on clean `main` from the same starting database produced the identical count, so the shrink is pre-existing behaviour, not a regression here. Worth its own issue; I did not fold it into this one.

## Schema

`event_id` added with the repo's existing `ALTER TABLE` + `try/catch` migration pattern. Both the read (`getTrackedSet`) and the write (`recordInvocation`) degrade to the old shape when the column is absent, so a database that never went through `getDb()` keeps working instead of throwing.

## Verification

- `bun test src/` — 191 pass, 0 fail (13 new tests; `recordNewInvocations` and `getTrackedSet` previously had none)
- `tsc --noEmit` — 0 errors
- Fresh database: 257 of 271 invocations record an id (codex 100%, opencode 100%, claude 90%)
- Repeat scans idempotent across three consecutive full runs
- Against an existing database, row counts match `main` exactly, and zero duplicate `(skill, session, event_id)` groups