### PR TITLE
docs(skill): document every command and pin the skill to the CLI version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,6 +58,12 @@ jobs:
         working-directory: .
         run: bun install --frozen-lockfile
 
+      # The published skill must not advertise a version it does not describe.
+      - name: Check skill version matches
+        if: steps.version.outputs.changed == 'true'
+        working-directory: .
+        run: bun run skill:version
+
       - name: Publish
         if: steps.version.outputs.changed == 'true'
         run: npm publish --access public

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
 		"build:web": "bun run --filter '@crafter/skillkit-web' build",
 		"lint": "biome check --write .",
 		"lint:check": "biome check .",
-		"type-check": "bun run --filter '*' type-check"
+		"type-check": "bun run --filter '*' type-check",
+		"skill:version": "bun run packages/skill/version.ts"
 	},
 	"devDependencies": {
 		"@biomejs/biome": "^2.2.0",

--- a/packages/skill/SKILL.md
+++ b/packages/skill/SKILL.md
@@ -1,44 +1,81 @@
 ---
 name: skillkit
-description: "Local-first analytics for AI agent skills. Use when user asks about skill usage, analytics, health, context budget, or wants to clean up unused skills."
+version: 0.11.0
+description: "Local-first analytics for AI agent skills. Use when user asks about skill usage, analytics, health, context budget, MCP context cost, token burn rate, or wants to clean up unused skills."
 ---
 
 # SkillKit
 
-Analytics for AI agent skills. Tracks usage, measures context budget, and prunes what you don't use.
+Analytics for AI agent skills. Tracks usage, measures what your context window costs, and prunes what you don't use. All data stays on the machine in `~/.skillkit/analytics.db`.
 
 ## Commands
 
-SkillKit is an npm CLI. Run commands with `npx @crafter/skillkit <command>` or install globally first (`npm i -g @crafter/skillkit`).
+Run with `npx @crafter/skillkit <command>`, or install globally (`npm i -g @crafter/skillkit`) and drop the prefix.
 
-- `npx @crafter/skillkit stats` - Usage analytics with sparklines (auto-scans on first run)
-- `npx @crafter/skillkit stats --all` - Show all skills, not just top 10
-- `npx @crafter/skillkit stats --days N` - Change time range (default: 30)
-- `npx @crafter/skillkit stats --all --days 90` - Full list over 90 days
-- `npx @crafter/skillkit list` - List installed skills with size and context budget
-- `npx @crafter/skillkit health` - Health check: unused skills, context budget, DB status
-- `npx @crafter/skillkit prune` - List unused skills. Add `--yes` to confirm deletion
-- `npx @crafter/skillkit scan` - Force re-scan (runs automatically, rarely needed)
-- `npx @crafter/skillkit scan --include-commands` - Also track slash commands
-- Any command with `--claude` or `--opencode` to filter by agent
+### Usage
 
-## When to Use
+- `stats` - Top skills with sparklines, streaks, weekly velocity (auto-scans on first run)
+- `stats --all` - Every skill, not just the top 10
+- `stats --days N` - Change the time range (default: 30)
+- `sessions` - Daily usage and cost across all agents
+- `graph` - 52-week contribution heatmap (alias: `contrib`)
 
-- User asks "which skills do I use the most?"
-- User asks "are there unused skills?" or "clean up my skills"
-- User wants to see skill analytics, usage trends, or context budget
-- User wants to optimize their skill setup
-- User asks about context window usage from skills
-- User asks "show me all my skill usage" or "full stats"
+### Context cost
 
-## Decision Guide
+- `context` - Tokens and cost loaded on every API call: CLAUDE.md and its imports, skill metadata, memory (alias: `ctx`)
+- `context --mcp` - Also measure MCP server tool schemas. Often the largest slice, and invisible without this flag. Spawns each configured server to read its tool list, so it takes a few seconds
+- `context --save-baseline <name>` - Save the current measurement
+- `context --compare <name>` - Diff against a saved baseline to see what grew and why
+- `context --list-baselines` / `context --delete-baseline <name>`
+- `context --sonnet` / `context --haiku` - Price against another model (default: opus)
+- `context --turns N` - Turns per session for the cost estimate (default: 40)
 
-1. First time? Run `npx @crafter/skillkit stats` - it auto-discovers and indexes everything
-2. Full picture? Run `npx @crafter/skillkit stats --all --days 90`
-3. Want cleanup? Run `npx @crafter/skillkit health` then `npx @crafter/skillkit prune --yes`
-4. Quick overview? Run `npx @crafter/skillkit list` for installed skills with sizes
-5. Filter by agent? Add `--claude` or `--opencode` to any command
+### Spend
 
-## How It Works
+- `burn` - Token burn rate, per-model breakdown, plan utilization
+- `burn --days N` - Time range (default: 30)
+- `burn --plan N` - Monthly plan cost in USD for the utilization figure
 
-Discovers skills for Claude Code and OpenCode. Scans skill directories and project-local `.claude/skills/` for installed skills. Indexes Claude Code JSONL sessions and OpenCode SQLite sessions. Extracts `Skill` tool_use blocks from assistant messages and `<command-name>` tags from user messages. Auto-deduplicates on every scan. All data stored locally in `~/.skillkit/analytics.db`.
+### Maintenance
+
+- `health` - Unused skills, metadata budget, database status
+- `list` - Installed skills with size and context budget (alias: `ls`)
+- `prune` - List unused skills. Add `--yes` to actually delete
+- `scan` - Force a re-scan. Runs automatically, rarely needed by hand
+- `scan --full` - Ignore the incremental cache and re-read every session
+- `scan --include-commands` - Also track slash commands, not just skills
+- `auto` - Install the session hook so scans happen on their own
+
+### Deeper analysis
+
+- `trace` - Trace how a skill gets invoked
+- `conflicts` - Find skills whose descriptions overlap enough to misfire
+- `coverage` - Which installed skills actually see use
+
+Add `--json` to most commands for machine-readable output. Filter by agent with `--claude`, `--codex`, `--cursor`, `--opencode`, `--gemini`, and the like.
+
+## When to use
+
+- "Which skills do I actually use?" or "are there unused skills?"
+- "What is my context window costing me?" or "why is my context so big?"
+- "How much am I spending on tokens?" or questions about burn rate and plan utilization
+- "Did installing that pack blow up my context?" - baseline first, compare later
+- Before and after adding MCP servers or skill packs, to see the real cost
+- Cleaning up or optimizing an agent setup
+
+## Decision guide
+
+1. First time: `stats`. It discovers and indexes everything on its own.
+2. Context feels bloated: `context --mcp`. MCP tool schemas are usually the biggest and least visible slice.
+3. About to install a pack or server: `context --save-baseline before`, then `context --mcp --compare before` afterwards.
+4. Cleanup: `health`, then `prune --yes`.
+5. Cost questions: `burn --days 30`.
+6. Full picture: `stats --all --days 90`.
+
+## How it works
+
+Indexes sessions from 14 agents, including Claude Code, Codex, Cursor, OpenCode, Windsurf, Cline, Roo, Kilocode, Continue, Goose, Copilot CLI, Gemini CLI, Amp, and OpenHands. Reads each agent's own session store (JSONL files, SQLite databases, VS Code workspace state) and extracts skill invocations.
+
+Invocations are deduplicated by a stable per-event id from the source (tool-call id, event id) where one exists, falling back to a timestamp key for sources that provide none. That keeps a re-scan from double-counting an event seen through two stores with different timestamps.
+
+`context` measures the eager cost, meaning what the model pays before you type anything. Token counts are approximated from character length, so treat them as an order of magnitude rather than an exact count. Servers that fail to start, time out, or use a transport that cannot be probed offline are reported as unmeasured, never as zero.

--- a/packages/skill/version.ts
+++ b/packages/skill/version.ts
@@ -1,0 +1,56 @@
+/**
+ * Keeps packages/skill/SKILL.md's version in step with the CLI it documents.
+ *
+ *   bun run skill:version         check, non-zero exit on mismatch (CI)
+ *   bun run skill:version --write update SKILL.md to the CLI's version
+ *
+ * A skill that advertises a version it does not actually describe is worse
+ * than one carrying no version at all, so the check is a hard failure rather
+ * than a warning.
+ */
+import { readFileSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+
+const here = dirname(new URL(import.meta.url).pathname);
+const cliPackageJson = join(here, "..", "cli", "package.json");
+const skillMd = join(here, "SKILL.md");
+
+const cliVersion = (
+	JSON.parse(readFileSync(cliPackageJson, "utf-8")) as { version: string }
+).version;
+
+const contents = readFileSync(skillMd, "utf-8");
+const match = contents.match(/^version:\s*(.+)$/m);
+const skillVersion = match?.[1]?.trim();
+
+const write = process.argv.includes("--write");
+
+if (write) {
+	const next = match
+		? contents.replace(/^version:\s*.+$/m, `version: ${cliVersion}`)
+		: contents.replace(/^(name:\s*.+)$/m, `$1\nversion: ${cliVersion}`);
+
+	if (next === contents) {
+		console.log(`skill version already ${cliVersion}`);
+	} else {
+		writeFileSync(skillMd, next);
+		console.log(`skill version set to ${cliVersion}`);
+	}
+	process.exit(0);
+}
+
+if (!skillVersion) {
+	console.error("packages/skill/SKILL.md has no version field in frontmatter");
+	console.error("run: bun run skill:version --write");
+	process.exit(1);
+}
+
+if (skillVersion !== cliVersion) {
+	console.error("skill version does not match the CLI");
+	console.error(`  packages/cli/package.json : ${cliVersion}`);
+	console.error(`  packages/skill/SKILL.md   : ${skillVersion}`);
+	console.error("run: bun run skill:version --write");
+	process.exit(1);
+}
+
+console.log(`skill version matches CLI (${cliVersion})`);


### PR DESCRIPTION
Follow-up to #30 and #31. `SKILL.md` is what an agent reads to learn what this tool can do, so anything missing from it effectively does not exist for that agent.

## What was missing

It documented **8 of 16 commands** and **2 of 14 agents**, and never mentioned `context` at all. An agent asked "why is my context so big?" had no way to know the answer was one command away.

Absent entirely: `context`, `burn`, `sessions`, `graph`, `trace`, `conflicts`, `coverage`, `auto`.

## Changes

- Full command list, grouped by what you'd reach for it: usage, context cost, spend, maintenance, deeper analysis
- `context --mcp`, `--save-baseline`, `--compare` documented, with the note that `--mcp` spawns each server and takes a few seconds
- Agent list corrected to the 14 the registry actually supports
- Decision guide covers the baseline-then-compare flow, which is the whole point of drift tracking and had no representation
- Two limits stated plainly rather than glossed: token counts are approximated from character length, and MCP servers that can't be probed are reported as unmeasured, never as zero
- Mentions the event-id dedupe from #31, since it changes what the invocation numbers mean

## Version pinning

The skill had no version field. It now carries one, held equal to the CLI's:

```
bun run skill:version           # check, exits non-zero on mismatch
bun run skill:version --write   # repair
```

The release workflow runs the check before publishing, so bumping the CLI cannot ship a skill advertising a version it does not describe. Verified in all three states: passes when matched, exits 1 on a simulated drift to 0.9.9, and `--write` repairs it.

## Verification

- All 9 documented commands confirmed to exist by running each one
- 191 tests pass, biome clean
- `bun run skill:version` passes at 0.11.0