### PR TITLE
docs: document --mcp-timeout flag in README flags table

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ AI coding agents load skills into their context window on every session. More sk
 | Flag | Applies to | Description |
 |------|-----------|-------------|
 | `--mcp` | context | Measure MCP server tool schemas (spawns each server) |
+| `--mcp-timeout N` | context | Timeout in seconds per MCP server (default: 20s; server skipped on timeout) |
 | `--compare <name>` | context | Diff against a saved baseline |
 | `--save-baseline <name>` | context | Save the current measurement |
 | `--days N` | stats | Time range in days (default: 30) |


### PR DESCRIPTION
## Fix

Adds the missing `--mcp-timeout N` row to the README flags table, documenting:
- Default: 20s per MCP server
- Behavior: server is skipped on timeout (not hung)

## Verification

`--mcp-timeout` is implemented in `packages/cli/src/commands/context.ts`:

```ts
const mcpTimeout = Number(flagValue(args, \&quot;--mcp-timeout\&quot;) ?? 20) * 1000;
```

The timeout is passed as `timeoutMs` when spawning MCP servers, matching the documented behavior (server skipped, not hung).

Fixes issue #37.