### PR TITLE
docs: list all 13 CLI commands in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,18 @@ AI coding agents load skills into their context window on every session. More sk
 
 | Command | Description |
 |---------|-------------|
+| `auto` | Auto-scan after Claude Code sessions |
 | `stats` | Usage analytics with sparklines (auto-scans on first run) |
 | `list` | List installed skills with size and context budget |
 | `health` | Health check: unused skills, context budget, DB |
+| `trace` | Run and record skill execution traces |
+| `conflicts` | Test skills for trigger collisions |
+| `coverage` | Analyze dead weight in a skill |
 | `prune` | Remove unused skills to reclaim context budget |
 | `context` | Context tax: tokens and cost loaded on every API call |
 | `burn` | Token burn rate and cost across agents |
+| `sessions` | Daily usage across all agents |
+| `graph` | 52-week contribution heatmap |
 | `scan` | Force re-scan (runs automatically, rarely needed) |
 
 ### Flags


### PR DESCRIPTION
## What & why

Adds the six missing commands to the README table so it matches the 13 switch cases in `packages/cli/src/bin.ts`: `trace`, `conflicts`, `coverage`, `sessions`, `graph`, and `auto`.

Closes #34.

## Verification

- Descriptions were taken from the help text in `bin.ts`.
- Docs-only change.
