### PR TITLE
fix(release): sync skill version and bump to unblock stalled release

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@crafter/skillkit",
-	"version": "0.11.1",
+	"version": "0.11.2",
 	"description": "Local-first analytics for AI agent skills. Track usage, measure context budget, and prune what you don't use.",
 	"type": "module",
 	"bin": {

--- a/packages/skill/SKILL.md
+++ b/packages/skill/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: skillkit
-version: 0.11.0
+version: 0.11.2
 description: "Local-first analytics for AI agent skills. Use when user asks about skill usage, analytics, health, context budget, MCP context cost, token burn rate, or wants to clean up unused skills."
 ---
 


### PR DESCRIPTION
Fixes #43.

The 2026-08-04 release run failed before `npm publish` because `packages/skill/SKILL.md` (0.11.0) didn't match `packages/cli/package.json` (0.11.1). That left the `wait`-as-skill fix from #31 unpublished — npm still serves 0.11.0, which misclassifies Codex's `wait` polling tool as a skill invocation.

## Change
- Synced `packages/skill/SKILL.md` version to the CLI version
- Bumped `packages/cli/package.json` to 0.11.2 to re-trigger the path-filtered release workflow

## How to check
- `bun run skill:version` passes (versions match)
- Merging to main should trigger `Release` and publish 0.11.2 to npm