### PR TITLE
fix(prune): surface errors instead of swallowing them

### DIFF
--- a/packages/cli/src/__tests__/prune.test.ts
+++ b/packages/cli/src/__tests__/prune.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from "bun:test";
+import {
+	chmodSync,
+	existsSync,
+	lstatSync,
+	mkdirSync,
+	mkdtempSync,
+	readFileSync,
+	rmSync,
+	symlinkSync,
+	writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+	isRegistrySkill,
+	removeFromLockFile,
+	removeSymlinks,
+} from "../commands/prune";
+
+describe("prune helpers", () => {
+	let tmpHome: string;
+	let originalHome: string | undefined;
+	let errorSpy: ReturnType<typeof spyOn>;
+
+	beforeEach(() => {
+		originalHome = process.env.HOME;
+		tmpHome = mkdtempSync(join(tmpdir(), "skillkit-prune-"));
+		process.env.HOME = tmpHome;
+		errorSpy = spyOn(console, "error").mockImplementation(() => {});
+	});
+
+	afterEach(() => {
+		errorSpy.mockRestore();
+		process.env.HOME = originalHome;
+		rmSync(tmpHome, { recursive: true, force: true });
+	});
+
+	function lockPath(): string {
+		return join(tmpHome, ".agents", ".skill-lock.json");
+	}
+
+	function writeMalformedLock(contents = "not-json{"): string {
+		mkdirSync(join(tmpHome, ".agents"), { recursive: true });
+		writeFileSync(lockPath(), contents, "utf-8");
+		return contents;
+	}
+
+	it("warns on malformed lock and isRegistrySkill returns false without mutating", () => {
+		const original = writeMalformedLock("not-json{");
+
+		expect(isRegistrySkill("skill-a")).toBe(false);
+		expect(errorSpy).toHaveBeenCalled();
+		const message = String(errorSpy.mock.calls[0]?.[0] ?? "");
+		expect(message).toContain("skill-lock");
+		expect(readFileSync(lockPath(), "utf-8")).toBe(original);
+	});
+
+	it("warns on malformed lock and removeFromLockFile preserves corrupt bytes", () => {
+		const original = writeMalformedLock("not-json{");
+
+		removeFromLockFile("skill-a");
+
+		expect(errorSpy).toHaveBeenCalled();
+		const message = String(errorSpy.mock.calls[0]?.[0] ?? "");
+		expect(message).toContain("skill-lock");
+		expect(readFileSync(lockPath(), "utf-8")).toBe(original);
+	});
+
+	it("isRegistrySkill returns correctly for a valid lock without warnings", () => {
+		mkdirSync(join(tmpHome, ".agents"), { recursive: true });
+		writeFileSync(
+			lockPath(),
+			`${JSON.stringify({ skills: { "skill-a": true } }, null, 2)}\n`,
+			"utf-8",
+		);
+
+		expect(isRegistrySkill("skill-a")).toBe(true);
+		expect(isRegistrySkill("skill-b")).toBe(false);
+		expect(errorSpy).not.toHaveBeenCalled();
+	});
+
+	it("removeFromLockFile deletes an entry from a valid lock without warnings", () => {
+		mkdirSync(join(tmpHome, ".agents"), { recursive: true });
+		writeFileSync(
+			lockPath(),
+			`${JSON.stringify(
+				{ skills: { "skill-a": true, "skill-b": true } },
+				null,
+				2,
+			)}\n`,
+			"utf-8",
+		);
+
+		removeFromLockFile("skill-a");
+
+		expect(errorSpy).not.toHaveBeenCalled();
+		const data = JSON.parse(readFileSync(lockPath(), "utf-8")) as {
+			skills: Record<string, unknown>;
+		};
+		expect(data.skills["skill-a"]).toBeUndefined();
+		expect(data.skills["skill-b"]).toBe(true);
+	});
+
+	it("removeSymlinks skips regular files, removes dangling links, warns on failure", () => {
+		const skillsDir = join(tmpHome, ".cursor", "skills");
+		mkdirSync(skillsDir, { recursive: true });
+
+		const regularPath = join(skillsDir, "skill-regular");
+		writeFileSync(regularPath, "not a symlink", "utf-8");
+
+		const danglingPath = join(skillsDir, "skill-dangling");
+		symlinkSync("/nonexistent/skill-dangling-target", danglingPath);
+
+		const blockedDir = join(tmpHome, ".claude", "skills");
+		mkdirSync(blockedDir, { recursive: true });
+		const blockedPath = join(blockedDir, "skill-blocked");
+		symlinkSync("/nonexistent/skill-blocked-target", blockedPath);
+		chmodSync(blockedDir, 0o555);
+
+		try {
+			const cleaned = removeSymlinks("skill-regular");
+			expect(cleaned).toBe(0);
+			expect(existsSync(regularPath)).toBe(true);
+			expect(lstatSync(regularPath).isSymbolicLink()).toBe(false);
+			expect(errorSpy).not.toHaveBeenCalled();
+
+			errorSpy.mockClear();
+			const danglingCleaned = removeSymlinks("skill-dangling");
+			expect(danglingCleaned).toBe(1);
+			expect(existsSync(danglingPath)).toBe(false);
+			try {
+				lstatSync(danglingPath);
+				expect.unreachable("dangling symlink should have been removed");
+			} catch {
+				/* expected ENOENT */
+			}
+			expect(errorSpy).not.toHaveBeenCalled();
+
+			errorSpy.mockClear();
+			const blockedCleaned = removeSymlinks("skill-blocked");
+			expect(blockedCleaned).toBe(0);
+			expect(errorSpy).toHaveBeenCalled();
+			const message = String(errorSpy.mock.calls[0]?.[0] ?? "");
+			expect(message).toContain("symlink");
+			expect(lstatSync(blockedPath).isSymbolicLink()).toBe(true);
+		} finally {
+			chmodSync(blockedDir, 0o755);
+		}
+	});
+
+	it("treats a missing lock file as non-error silence", () => {
+		expect(isRegistrySkill("skill-a")).toBe(false);
+		removeFromLockFile("skill-a");
+		expect(errorSpy).not.toHaveBeenCalled();
+		expect(existsSync(lockPath())).toBe(false);
+	});
+});

--- a/packages/cli/src/commands/prune.ts
+++ b/packages/cli/src/commands/prune.ts
@@ -1,7 +1,6 @@
 import {
 	existsSync,
 	lstatSync,
-	readdirSync,
 	readFileSync,
 	rmSync,
 	unlinkSync,
@@ -14,61 +13,86 @@ import { getDb } from "../db/schema";
 import { scanInstalledSkills } from "../scanner/skills";
 import { bold, cyan, dim, red, yellow } from "../tui/colors";
 
-const HOME = homedir();
-const LOCK_PATH = join(HOME, ".agents", ".skill-lock.json");
+/** Prefer HOME so tests can isolate; Bun caches os.homedir() at process start. */
+function getHome(): string {
+	return process.env.HOME || homedir();
+}
 
-const AGENT_SKILL_DIRS = [
-	join(HOME, ".claude", "skills"),
-	join(HOME, ".cursor", "skills"),
-	join(HOME, ".codex", "skills"),
-	join(HOME, ".codeium", "windsurf", "skills"),
-	join(HOME, ".config", "amp", "skills"),
-	join(HOME, ".config", "opencode", "skills"),
-	join(HOME, ".copilot", "skills"),
-	join(HOME, ".pi", "agent", "skills"),
-	join(HOME, ".gemini", "antigravity", "skills"),
-];
+function getLockPath(): string {
+	return join(getHome(), ".agents", ".skill-lock.json");
+}
 
-function removeFromLockFile(skillName: string): void {
-	if (!existsSync(LOCK_PATH)) return;
+function getAgentSkillDirs(): string[] {
+	const home = getHome();
+	return [
+		join(home, ".claude", "skills"),
+		join(home, ".cursor", "skills"),
+		join(home, ".codex", "skills"),
+		join(home, ".codeium", "windsurf", "skills"),
+		join(home, ".config", "amp", "skills"),
+		join(home, ".config", "opencode", "skills"),
+		join(home, ".copilot", "skills"),
+		join(home, ".pi", "agent", "skills"),
+		join(home, ".gemini", "antigravity", "skills"),
+	];
+}
+
+function readLockData(): { skills?: Record<string, unknown> } | null {
+	const lockPath = getLockPath();
+	if (!existsSync(lockPath)) return null;
 	try {
-		const data = JSON.parse(readFileSync(LOCK_PATH, "utf-8"));
-		if (data.skills && data.skills[skillName]) {
-			delete data.skills[skillName];
-			writeFileSync(LOCK_PATH, JSON.stringify(data, null, 2) + "\n", "utf-8");
+		const parsed: unknown = JSON.parse(readFileSync(lockPath, "utf-8"));
+		if (
+			parsed === null ||
+			typeof parsed !== "object" ||
+			Array.isArray(parsed)
+		) {
+			return {};
 		}
-	} catch {
-		/* empty */
+		return parsed as { skills?: Record<string, unknown> };
+	} catch (error) {
+		console.error(
+			red(`Warning: could not read ${lockPath}: ${(error as Error).message}`),
+		);
+		return null;
 	}
 }
 
-function removeSymlinks(skillName: string): number {
+export function removeFromLockFile(skillName: string): void {
+	const lockPath = getLockPath();
+	const data = readLockData();
+	if (data === null) return;
+	if (data.skills?.[skillName]) {
+		delete data.skills[skillName];
+		writeFileSync(lockPath, `${JSON.stringify(data, null, 2)}\n`, "utf-8");
+	}
+}
+
+export function removeSymlinks(skillName: string): number {
 	let cleaned = 0;
-	for (const agentDir of AGENT_SKILL_DIRS) {
+	for (const agentDir of getAgentSkillDirs()) {
 		const linkPath = join(agentDir, skillName);
-		if (!existsSync(linkPath)) continue;
 		try {
 			const stat = lstatSync(linkPath);
 			if (stat.isSymbolicLink()) {
 				unlinkSync(linkPath);
 				cleaned++;
 			}
-		} catch {
-			/* empty */
+		} catch (error) {
+			const err = error as NodeJS.ErrnoException;
+			if (err.code === "ENOENT") continue;
+			console.error(
+				yellow(`Warning: could not remove symlink ${linkPath}: ${err.message}`),
+			);
 		}
 	}
 	return cleaned;
 }
 
-function isRegistrySkill(skillName: string): boolean {
-	if (!existsSync(LOCK_PATH)) return false;
-	try {
-		const data = JSON.parse(readFileSync(LOCK_PATH, "utf-8"));
-		return !!(data.skills && data.skills[skillName]);
-	} catch {
-		/* empty */
-	}
-	return false;
+export function isRegistrySkill(skillName: string): boolean {
+	const data = readLockData();
+	if (data === null) return false;
+	return !!data.skills?.[skillName];
 }
 
 function removeSkillClean(name: string, path: string): boolean {
@@ -80,7 +104,7 @@ function removeSkillClean(name: string, path: string): boolean {
 		}
 		rmSync(path, { recursive: true, force: true });
 		if (isRegistry) {
-			const canonicalPath = join(HOME, ".agents", "skills", name);
+			const canonicalPath = join(getHome(), ".agents", "skills", name);
 			if (existsSync(canonicalPath) && canonicalPath !== path) {
 				rmSync(canonicalPath, { recursive: true, force: true });
 			}


### PR DESCRIPTION
## Summary

`prune` no longer fails silently. A malformed `~/.agents/.skill-lock.json` or a symlink removal failure now prints a visible warning to stderr (issue #36).

- `readLockData()`: a missing lock is not an error (no warning); a corrupt lock warns via `console.error(red(...))`, returns null, and is **never overwritten** — the malformed file is preserved.
- `removeSymlinks()`: per-link warnings (`yellow`) on non-ENOENT failures; continues cleaning other agent dirs.
- `getHome()` honors `$HOME` so tests can isolate (Bun caches `os.homedir()` at process start).

### Bonus fix (flagging for review)

While characterizing, tests proved `removeSymlinks` **never removed dangling symlinks** — `existsSync(linkPath)` returns false for a broken link, so `prune` skipped it and the user believed the skill was fully removed. Switched to `lstatSync`-based detection (ENOENT ignored, real errors warn). This is a deliberate behavior change; drop it if maintainers prefer to keep the issue strictly to warnings.

### Tests

`packages/cli/src/__tests__/prune.test.ts` (HOME pointed at a tmp dir):
- malformed lock → warning emitted, file bytes preserved, `isRegistrySkill` false
- valid lock → no warnings, add/remove works
- dangling symlink → cleaned now (was skipped before)
- regular file (not a symlink) → not removed, no warning
- missing lock → silence (absence is not an error)

## Verification

```bash
bun test                                     # 197 pass, 0 fail
bun run --filter '@crafter/skillkit' type-check
bunx biome check packages/cli/src/commands/prune.ts packages/cli/src/__tests__/prune.test.ts  # clean
```

Closes #36