### PR TITLE
fix: constrain prune paths to skill directories

### DIFF
--- a/packages/cli/src/__tests__/prune.test.ts
+++ b/packages/cli/src/__tests__/prune.test.ts
@@ -155,4 +155,22 @@ describe("prune helpers", () => {
 		expect(errorSpy).not.toHaveBeenCalled();
 		expect(existsSync(lockPath())).toBe(false);
 	});
+
+	it("rejects traversal names without touching outside symlinks", () => {
+		const cursorDir = join(tmpHome, ".cursor");
+		const outsideTarget = join(tmpHome, "outside-target");
+		const outsideLink = join(cursorDir, "outside-link");
+		mkdirSync(cursorDir, { recursive: true });
+		mkdirSync(outsideTarget);
+		symlinkSync(outsideTarget, outsideLink);
+
+		expect(removeSymlinks("../outside-link")).toBe(0);
+		expect(lstatSync(outsideLink).isSymbolicLink()).toBe(true);
+		expect(removeSymlinks("..\\outside-link")).toBe(0);
+		expect(lstatSync(outsideLink).isSymbolicLink()).toBe(true);
+		expect(errorSpy).toHaveBeenCalledTimes(2);
+		expect(String(errorSpy.mock.calls[0]?.[0] ?? "")).toContain(
+			"unsafe skill name",
+		);
+	});
 });

--- a/packages/cli/src/commands/prune.ts
+++ b/packages/cli/src/commands/prune.ts
@@ -7,7 +7,7 @@ import {
 	writeFileSync,
 } from "node:fs";
 import { homedir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 import { getTopSkills } from "../db/queries";
 import { getDb } from "../db/schema";
 import { scanInstalledSkills } from "../scanner/skills";
@@ -35,6 +35,23 @@ function getAgentSkillDirs(): string[] {
 		join(home, ".pi", "agent", "skills"),
 		join(home, ".gemini", "antigravity", "skills"),
 	];
+}
+
+function isSafeSkillName(skillName: string): boolean {
+	return (
+		skillName.length > 0 &&
+		skillName !== "." &&
+		skillName !== ".." &&
+		!skillName.includes("/") &&
+		!skillName.includes("\\") &&
+		basename(skillName) === skillName
+	);
+}
+
+function warnUnsafeSkillName(skillName: string): void {
+	console.error(
+		red(`Warning: refusing unsafe skill name ${JSON.stringify(skillName)}`),
+	);
 }
 
 function readLockData(): { skills?: Record<string, unknown> } | null {
@@ -69,6 +86,10 @@ export function removeFromLockFile(skillName: string): void {
 }
 
 export function removeSymlinks(skillName: string): number {
+	if (!isSafeSkillName(skillName)) {
+		warnUnsafeSkillName(skillName);
+		return 0;
+	}
 	let cleaned = 0;
 	for (const agentDir of getAgentSkillDirs()) {
 		const linkPath = join(agentDir, skillName);
@@ -96,6 +117,10 @@ export function isRegistrySkill(skillName: string): boolean {
 }
 
 function removeSkillClean(name: string, path: string): boolean {
+	if (!isSafeSkillName(name)) {
+		warnUnsafeSkillName(name);
+		return false;
+	}
 	try {
 		const isRegistry = isRegistrySkill(name);
 		if (isRegistry) {


### PR DESCRIPTION
## Summary

- reject unsafe skill names before filesystem cleanup
- prevent path separators and traversal segments from reaching prune operations
- preserve targets outside configured skill directories
- add POSIX and Windows-style regression coverage

## Verification

- 233 CLI tests pass
- focused Biome check passes
- workspace typecheck passes
- workspace build passes
- regression test fails when the boundary check is removed
